### PR TITLE
set minutes to 30 so it count as validated when we select 00h30 for i…

### DIFF
--- a/src/main/java/com/farao_community/farao/gridcapa/task_manager/TaskManager.java
+++ b/src/main/java/com/farao_community/farao/gridcapa/task_manager/TaskManager.java
@@ -59,7 +59,7 @@ public class TaskManager {
                 LocalDateTime currentTime = toUtc(interval[0], processProperties.getTimezone());
                 LocalDateTime endTime = toUtc(interval[1], processProperties.getTimezone());
                 while (currentTime.isBefore(endTime)) {
-                    final LocalDateTime finalTime = currentTime;
+                    final LocalDateTime finalTime = currentTime.withMinute(30);
                     Task task = taskRepository.findByTimestamp(finalTime).orElseGet(() -> {
                         LOGGER.info("New task added for {} on {}", processProperties.getTag(), finalTime);
                         return new Task(finalTime, processProperties.getInputs());


### PR DESCRIPTION
…nstance in the hmi

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
We had minutes set to 0. When we select for instance 00:30 in the hmi, i couldnt see that the file was validated.
I set the minute to 30 for every daily file so it appears validated when we select xx:30 



