### PR TITLE
Configuration correction:

### DIFF
--- a/gridcapa-task-manager-app/src/main/resources/application.yml
+++ b/gridcapa-task-manager-app/src/main/resources/application.yml
@@ -56,7 +56,7 @@ task-server:
 
 minio-adapter:
   bucket: ${GRIDCAPA_MINIO_BUCKET:gridcapa}
-  base-path: ${GRIDCAPA_MINIO_BASE_PATH:""}
+  base-path: ${GRIDCAPA_MINIO_BASE_PATH:}
   url: ${GRIDCAPA_MINIO_URL:http://localhost:9000}
   access-key: ${GRIDCAPA_MINIO_ACCESS_KEY:gridcapa}
   secret-key: ${GRIDCAPA_MINIO_SECRET_KEY:gridcapa}


### PR DESCRIPTION
${GRIDCAPA_MINIO_BASE_PATH:""} the default value is not read as an empty string but as a string with two " character. this error introduce two " in the file URL encoded with %22. Because of the bad url, it becomes impossible to download the file or launch a calcul


