### PR TITLE
Optimize front end notification with a stomp server. 

### DIFF
--- a/gridcapa-task-manager-app/pom.xml
+++ b/gridcapa-task-manager-app/pom.xml
@@ -74,6 +74,10 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManager.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManager.java
@@ -98,7 +98,7 @@ public class TaskManager {
     private void updateTaskStatus(Task task, TaskStatus taskStatus) {
         task.setStatus(taskStatus);
         taskRepository.saveAndFlush(task);
-        taskUpdateNotifier.notify(task);
+        taskUpdateNotifier.notify(task, true);
         LOGGER.debug("Task status has been updated on {} to {}", task.getTimestamp(), taskStatus);
     }
 
@@ -119,7 +119,7 @@ public class TaskManager {
                     OffsetDateTime offsetDateTime = OffsetDateTime.parse(loggerEvent.getTimestamp());
                     task.addProcessEvent(offsetDateTime, loggerEvent.getLevel(), loggerEvent.getMessage());
                     taskRepository.save(task);
-                    taskUpdateNotifier.notify(task);
+                    taskUpdateNotifier.notify(task, false);
                     LOGGER.debug("Task event has been added on {} provided by {}", task.getTimestamp(), loggerEvent.getServiceName());
                 } else {
                     LOGGER.warn("Task {} does not exist. Impossible to update task with log event", loggerEvent.getId());
@@ -299,7 +299,7 @@ public class TaskManager {
         List<String> availableInputFileTypes = task.getProcessFiles().stream()
             .filter(processFile -> MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE.equals(processFile.getFileGroup()))
             .map(ProcessFile::getFileType).collect(Collectors.toList());
-        if (availableInputFileTypes.size() == 0) {
+        if (availableInputFileTypes.isEmpty()) {
             task.setStatus(TaskStatus.NOT_CREATED);
         } else if (availableInputFileTypes.containsAll(taskManagerConfigurationProperties.getProcess().getInputs())) {
             task.setStatus(TaskStatus.READY);

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManager.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManager.java
@@ -98,7 +98,7 @@ public class TaskManager {
     private void updateTaskStatus(Task task, TaskStatus taskStatus) {
         task.setStatus(taskStatus);
         taskRepository.saveAndFlush(task);
-        taskUpdateNotifier.notify(task, true);
+        taskUpdateNotifier.notify(task);
         LOGGER.debug("Task status has been updated on {} to {}", task.getTimestamp(), taskStatus);
     }
 
@@ -119,7 +119,7 @@ public class TaskManager {
                     OffsetDateTime offsetDateTime = OffsetDateTime.parse(loggerEvent.getTimestamp());
                     task.addProcessEvent(offsetDateTime, loggerEvent.getLevel(), loggerEvent.getMessage());
                     taskRepository.save(task);
-                    taskUpdateNotifier.notify(task, false);
+                    taskUpdateNotifier.notify(task);
                     LOGGER.debug("Task event has been added on {} provided by {}", task.getTimestamp(), loggerEvent.getServiceName());
                 } else {
                     LOGGER.warn("Task {} does not exist. Impossible to update task with log event", loggerEvent.getId());

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/TaskUpdateNotifier.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/TaskUpdateNotifier.java
@@ -7,8 +7,8 @@
 package com.farao_community.farao.gridcapa.task_manager.app;
 
 import com.farao_community.farao.gridcapa.task_manager.api.TaskDto;
+import com.farao_community.farao.gridcapa.task_manager.app.configuration.WebsocketConfig;
 import com.farao_community.farao.gridcapa.task_manager.app.entities.Task;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -27,15 +27,14 @@ public class TaskUpdateNotifier {
     private final StreamBridge streamBridge;
     private final TaskDtoBuilder taskDtoBuilder;
 
-    @Value("${stomp.notify}")
-    private String notify;
+    private final SimpMessagingTemplate stompBridge;
+    private final WebsocketConfig websocketConfig;
 
-    private final SimpMessagingTemplate broker;
-
-    public TaskUpdateNotifier(StreamBridge streamBridge, TaskDtoBuilder taskDtoBuilder, SimpMessagingTemplate broker) {
+    public TaskUpdateNotifier(StreamBridge streamBridge, TaskDtoBuilder taskDtoBuilder, SimpMessagingTemplate broker, WebsocketConfig websocketConfig) {
         this.streamBridge = streamBridge;
         this.taskDtoBuilder = taskDtoBuilder;
-        this.broker = broker;
+        this.stompBridge = broker;
+        this.websocketConfig = websocketConfig;
     }
 
     public void notify(Task task, boolean withStatusUpdate) {
@@ -43,9 +42,8 @@ public class TaskUpdateNotifier {
         TaskDto taskdto = taskDtoBuilder.createDtoFromEntity(task);
         streamBridge.send(bindingName, taskdto);
         DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-        broker.convertAndSend(notify + "/update/" + fmt.format(task.getTimestamp()), taskdto);
-        broker.convertAndSend(notify + "/update/" + fmt.format(task.getTimestamp()).substring(0, 10), taskdto);
-
+        stompBridge.convertAndSend(websocketConfig.getNotify() + "/update/" + fmt.format(task.getTimestamp()), taskdto);
+        stompBridge.convertAndSend(websocketConfig.getNotify() + "/update/" + fmt.format(task.getTimestamp()).substring(0, 10), taskdto);
     }
 
     public void notify(Set<TaskWithStatusUpdate> taskWithStatusUpdateSet) {

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/configuration/WebsocketConfig.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/configuration/WebsocketConfig.java
@@ -35,4 +35,7 @@ public class WebsocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint(startingEndpoint).setAllowedOriginPatterns(allowedOrigin).withSockJS();
     }
 
+    public String getNotify() {
+        return notify;
+    }
 }

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/configuration/WebsocketConfig.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/configuration/WebsocketConfig.java
@@ -1,0 +1,38 @@
+package com.farao_community.farao.gridcapa.task_manager.app.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebsocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Value("${stomp.allowed-origin}")
+    private String[] allowedOrigin;
+
+    @Value("${stomp.starting-ws-endpoint}")
+    private String startingEndpoint;
+
+    @Value("${stomp.notify}")
+    private String notify;
+
+    @Value("${stomp.receive-request}")
+    private String receiver;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        // These are endpoints the client can subscribes to.
+        config.enableSimpleBroker(notify);
+        config.setApplicationDestinationPrefixes(receiver);
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint(startingEndpoint).setAllowedOriginPatterns(allowedOrigin).withSockJS();
+    }
+
+}

--- a/gridcapa-task-manager-app/src/main/resources/application.yml
+++ b/gridcapa-task-manager-app/src/main/resources/application.yml
@@ -63,6 +63,6 @@ minio-adapter:
 
 stomp:
   allowed-origin: http://localhost,http://127.0.0.1
-  starting-ws-endpoint: /web/notify
+  starting-ws-endpoint: /tasks/notify
   notify: /task
   receive-request: /app

--- a/gridcapa-task-manager-app/src/main/resources/application.yml
+++ b/gridcapa-task-manager-app/src/main/resources/application.yml
@@ -60,3 +60,9 @@ minio-adapter:
   url: ${GRIDCAPA_MINIO_URL:http://localhost:9000}
   access-key: ${GRIDCAPA_MINIO_ACCESS_KEY:gridcapa}
   secret-key: ${GRIDCAPA_MINIO_SECRET_KEY:gridcapa}
+
+stomp:
+  allowed-origin: http://localhost,http://127.0.0.1
+  starting-ws-endpoint: /web/notify
+  notify: /task
+  receive-request: /app

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerTest.java
@@ -14,9 +14,12 @@ import com.farao_community.farao.minio_adapter.starter.MinioAdapterConstants;
 import io.minio.messages.Event;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.stream.function.StreamBridge;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -30,12 +33,15 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
  */
 @SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class TaskManagerTest {
     private static final String INPUT_FILE_GROUP_VALUE = MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE;
 
-    @MockBean
-    private TaskUpdateNotifier taskUpdateNotifier; // Useful to avoid AMQP connection that would fail
+    @Autowired
+    private TaskUpdateNotifier taskUpdateNotifier;
 
+    @MockBean
+    private StreamBridge streamBridge; // Useful to avoid AMQP connection that would fail
     @MockBean
     private MinioAdapter minioAdapter;
 

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class TaskManagerTest {
     private static final String INPUT_FILE_GROUP_VALUE = MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE;
 
-    @MockBean
+    @Autowired
     private TaskUpdateNotifier taskUpdateNotifier; // Useful to avoid AMQP connection that would fail
 
     @MockBean

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class TaskManagerTest {
     private static final String INPUT_FILE_GROUP_VALUE = MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE;
 
-    @Autowired
+    @MockBean
     private TaskUpdateNotifier taskUpdateNotifier; // Useful to avoid AMQP connection that would fail
 
     @MockBean

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerTestUtil.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerTestUtil.java
@@ -28,7 +28,8 @@ public final class TaskManagerTestUtil {
             TaskManager.FILE_TYPE_METADATA_KEY, fileType,
             TaskManager.FILE_VALIDITY_INTERVAL_METADATA_KEY, validityInterval
         );
-        Mockito.when(event.userMetadata()).thenReturn(metadata);
+        //The following mock is not use in all test that call this methods. With the "lenient" add you avoid an exception
+        Mockito.lenient().when(event.userMetadata()).thenReturn(metadata);
         Mockito.when(event.objectName()).thenReturn(fileKey);
         Mockito.when(minioAdapter.generatePreSignedUrl(event.objectName())).thenReturn(fileUrl);
         return event;

--- a/gridcapa-task-manager-app/src/test/resources/application.yml
+++ b/gridcapa-task-manager-app/src/test/resources/application.yml
@@ -16,3 +16,9 @@ minio-adapter:
   url: http://minio.url
   access-key: gridcapa
   secret-key: gridcapa
+
+stomp:
+  allowed-origin: http://localhost,http://127.0.0.1
+  starting-ws-endpoint: /web/notify
+  notify: /task
+  receive-request: /app

--- a/gridcapa-task-manager-app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/gridcapa-task-manager-app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Only updates asked from the frontend are sent to it.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
yes


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
performance optimization


**What is the current behavior?** *(You can also link to an open issue here)*
sending all change no matter if they are needed by the front


**What is the new behavior (if this is a feature change)?**
Instead of sending all change in the database to the frontend, we only send them asked via a subscription


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
Yes the the log-notification-server can be deleted


**Other information**:
this new feature has to be deployed with the good version of gridcapa-app to work

(if any of the questions/checkboxes don't apply, please delete them entirely)
