### PR TITLE
fix a bug when a file arrives while multiple task are pending

### DIFF
--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandler.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandler.java
@@ -248,13 +248,7 @@ public class MinioHandler {
     }
 
     public void emptyWaitingList(OffsetDateTime timestamp) {
-        List<ProcessFileMinio> processFileToProcess = new ArrayList<>();
-        for (Map.Entry<ProcessFileMinio, List<OffsetDateTime>> entry : mapWaitingFilesNew.entrySet()) {
-            List<OffsetDateTime> listTimestamps = entry.getValue();
-            if (listTimestamps.contains(timestamp)) {
-                processFileToProcess.add(entry.getKey());
-            }
-        }
+        List<ProcessFileMinio> processFileToProcess = getProcessFileMinios(timestamp);
 
         boolean processEventAdded = false;
         for (ProcessFileMinio processFileMinio : processFileToProcess) {
@@ -278,6 +272,17 @@ public class MinioHandler {
             mapWaitingFilesNew.get(processFileMinio).clear();
         }
 
+    }
+
+    private List<ProcessFileMinio> getProcessFileMinios(OffsetDateTime timestamp) {
+        List<ProcessFileMinio> processFileToProcess = new ArrayList<>();
+        for (Map.Entry<ProcessFileMinio, List<OffsetDateTime>> entry : mapWaitingFilesNew.entrySet()) {
+            List<OffsetDateTime> listTimestamps = entry.getValue();
+            if (listTimestamps.contains(timestamp)) {
+                processFileToProcess.add(entry.getKey());
+            }
+        }
+        return processFileToProcess;
     }
 
     private boolean atLeastOneTaskIsRunningOrPending(List<TaskWithStatusUpdate> listTaskWithStatusUpdate) {

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandler.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandler.java
@@ -52,7 +52,7 @@ public class MinioHandler {
     private final TaskManagerConfigurationProperties taskManagerConfigurationProperties;
     private final TaskRepository taskRepository;
     private final TaskUpdateNotifier taskUpdateNotifier;
-    private final HashMap<ProcessFileMinio, List<OffsetDateTime>> mapWaitingFilesNew = new HashMap<>();
+    private HashMap<ProcessFileMinio, List<OffsetDateTime>> mapWaitingFilesNew = new HashMap<>();
 
     public MinioHandler(ProcessFileRepository processFileRepository, TaskManagerConfigurationProperties taskManagerConfigurationProperties, TaskRepository taskRepository, TaskUpdateNotifier taskUpdateNotifier) {
         this.processFileRepository = processFileRepository;
@@ -274,7 +274,7 @@ public class MinioHandler {
 
     }
 
-    private List<ProcessFileMinio> getProcessFileMinios(OffsetDateTime timestamp) {
+    List<ProcessFileMinio> getProcessFileMinios(OffsetDateTime timestamp) {
         List<ProcessFileMinio> processFileToProcess = new ArrayList<>();
         for (Map.Entry<ProcessFileMinio, List<OffsetDateTime>> entry : mapWaitingFilesNew.entrySet()) {
             List<OffsetDateTime> listTimestamps = entry.getValue();
@@ -359,5 +359,9 @@ public class MinioHandler {
                     return new TaskWithStatusUpdate(task, statusUpdated);
                 })
                 .collect(Collectors.toSet());
+    }
+
+    void setMapWaitingFilesNew(Map<ProcessFileMinio, List<OffsetDateTime>> mapWaitingFilesNew) {
+        this.mapWaitingFilesNew = (HashMap<ProcessFileMinio, List<OffsetDateTime>>) mapWaitingFilesNew;
     }
 }

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandler.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandler.java
@@ -265,6 +265,7 @@ public class MinioHandler {
                 if (!processEventAdded && task.getStatus().equals(TaskStatus.READY)) {
                     task.addProcessEvent(getProcessNow(), "WARN", "Task has been set to ready again because new inputs have been uploaded. Output files might be outdated.");
                     processEventAdded = true;
+                    taskUpdateNotifier.notify(task, true);
                 }
                 saveAndNotifyTasks(Collections.singleton(taskWithStatusUpdate));
             }

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandler.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandler.java
@@ -285,7 +285,7 @@ public class MinioHandler {
         return processFileToProcess;
     }
 
-    private boolean atLeastOneTaskIsRunningOrPending(List<TaskWithStatusUpdate> listTaskWithStatusUpdate) {
+    boolean atLeastOneTaskIsRunningOrPending(List<TaskWithStatusUpdate> listTaskWithStatusUpdate) {
         for (TaskWithStatusUpdate taskWithStatusUpdate : listTaskWithStatusUpdate) {
             TaskStatus taskStatus = taskWithStatusUpdate.getTask().getStatus();
             if (taskStatus.equals(TaskStatus.RUNNING) || taskStatus.equals(TaskStatus.PENDING)) {

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandler.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandler.java
@@ -223,7 +223,7 @@ public class MinioHandler {
 
     private List<TaskWithStatusUpdate> findAllTaskByTimestamp(List<OffsetDateTime> listTimestamps) {
         return listTimestamps.stream().map(ts -> taskRepository.findByTimestamp(ts)
-                        .map(task -> new TaskWithStatusUpdate(task, false))
+                        .map(task -> new TaskWithStatusUpdate(task, true))
                         .orElseGet(() -> new TaskWithStatusUpdate(taskRepository.save(new Task(ts)), true)))
                 .collect(Collectors.toList());
     }
@@ -265,7 +265,6 @@ public class MinioHandler {
                 if (!processEventAdded && task.getStatus().equals(TaskStatus.READY)) {
                     task.addProcessEvent(getProcessNow(), "WARN", "Task has been set to ready again because new inputs have been uploaded. Output files might be outdated.");
                     processEventAdded = true;
-                    taskUpdateNotifier.notify(task, true);
                 }
                 saveAndNotifyTasks(Collections.singleton(taskWithStatusUpdate));
             }

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandlerTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandlerTest.java
@@ -307,8 +307,6 @@ class MinioHandlerTest {
         assertTrue(minioHandler.atLeastOneTaskIsRunningOrPending(listTaskWithStatusUpdate));
     }
 
-
-
     public static Event createEvent(MinioAdapter minioAdapter, String processTag, String fileGroup, String fileType, String fileKey, String validityInterval) {
         Event event = Mockito.mock(Event.class);
         Map<String, String> metadata = Map.of(

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandlerTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandlerTest.java
@@ -8,6 +8,8 @@ package com.farao_community.farao.gridcapa.task_manager.app.service;
 
 import com.farao_community.farao.gridcapa.task_manager.app.*;
 import com.farao_community.farao.gridcapa.task_manager.app.entities.ProcessEvent;
+import com.farao_community.farao.gridcapa.task_manager.app.entities.ProcessFile;
+import com.farao_community.farao.gridcapa.task_manager.app.entities.ProcessFileMinio;
 import com.farao_community.farao.gridcapa.task_manager.app.entities.Task;
 import com.farao_community.farao.minio_adapter.starter.MinioAdapter;
 import com.farao_community.farao.minio_adapter.starter.MinioAdapterConstants;
@@ -22,10 +24,7 @@ import org.springframework.cloud.stream.function.StreamBridge;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.farao_community.farao.gridcapa.task_manager.api.TaskStatus.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -235,6 +234,45 @@ class MinioHandlerTest {
     }
 
     @Test
+    void testGetProcessFileMinios_noMatchingTimestamps() {
+        Map<ProcessFileMinio, List<OffsetDateTime>> mapWaitingFilesNew = new HashMap<>();
+        ProcessFileMinio file1 = new ProcessFileMinio(new ProcessFile(), null);
+        ProcessFileMinio file2 = new ProcessFileMinio(new ProcessFile(), null);
+        OffsetDateTime timestamp1 = OffsetDateTime.now().minusHours(1);
+        OffsetDateTime timestamp2 = OffsetDateTime.now().minusHours(2);
+        OffsetDateTime searchTimestamp = OffsetDateTime.now();
+
+        mapWaitingFilesNew.put(file1, List.of(timestamp1));
+        mapWaitingFilesNew.put(file2, List.of(timestamp2));
+
+        minioHandler.setMapWaitingFilesNew(mapWaitingFilesNew);
+        List<ProcessFileMinio> result = minioHandler.getProcessFileMinios(searchTimestamp);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetProcessFileMinios_someMatchingTimestamps() {
+        Map<ProcessFileMinio, List<OffsetDateTime>> mapWaitingFilesNew = new HashMap<>();
+        ProcessFileMinio file1 = new ProcessFileMinio(new ProcessFile(), null);
+        ProcessFileMinio file2 = new ProcessFileMinio(new ProcessFile(), null);
+        ProcessFileMinio file3 = new ProcessFileMinio(new ProcessFile(), null);
+        OffsetDateTime timestamp1 = OffsetDateTime.now().minusHours(1);
+        OffsetDateTime timestamp2 = OffsetDateTime.now().minusHours(2);
+
+        mapWaitingFilesNew.put(file1, List.of(timestamp1));
+        mapWaitingFilesNew.put(file2, Arrays.asList(timestamp1, timestamp2));
+        mapWaitingFilesNew.put(file3, List.of(timestamp2));
+
+        minioHandler.setMapWaitingFilesNew(mapWaitingFilesNew);
+        List<ProcessFileMinio> result = minioHandler.getProcessFileMinios(timestamp1);
+
+        assertEquals(2, result.size());
+        assertTrue(result.contains(file1));
+        assertTrue(result.contains(file2));
+    }
+
+    @Test
     void testAtLeastOneTaskIsRunningOrPendingNoTasks() {
         List<TaskWithStatusUpdate> listTaskWithStatusUpdate = List.of();
         assertFalse(minioHandler.atLeastOneTaskIsRunningOrPending(listTaskWithStatusUpdate));
@@ -268,6 +306,8 @@ class MinioHandlerTest {
         );
         assertTrue(minioHandler.atLeastOneTaskIsRunningOrPending(listTaskWithStatusUpdate));
     }
+
+
 
     public static Event createEvent(MinioAdapter minioAdapter, String processTag, String fileGroup, String fileType, String fileKey, String validityInterval) {
         Event event = Mockito.mock(Event.class);

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandlerTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/MinioHandlerTest.java
@@ -234,7 +234,7 @@ class MinioHandlerTest {
     }
 
     @Test
-    void testGetProcessFileMinios_noMatchingTimestamps() {
+    void testGetProcessFileMiniosNoMatchingTimestamps() {
         Map<ProcessFileMinio, List<OffsetDateTime>> mapWaitingFilesNew = new HashMap<>();
         ProcessFileMinio file1 = new ProcessFileMinio(new ProcessFile(), null);
         ProcessFileMinio file2 = new ProcessFileMinio(new ProcessFile(), null);
@@ -252,7 +252,7 @@ class MinioHandlerTest {
     }
 
     @Test
-    void testGetProcessFileMinios_someMatchingTimestamps() {
+    void testGetProcessFileMiniosSomeMatchingTimestamps() {
         Map<ProcessFileMinio, List<OffsetDateTime>> mapWaitingFilesNew = new HashMap<>();
         ProcessFileMinio file1 = new ProcessFileMinio(new ProcessFile(), null);
         ProcessFileMinio file2 = new ProcessFileMinio(new ProcessFile(), null);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
Before, when we ran all timestamp at once with the button in the business date view, if we uploaded new file while tasks were running/pending, the file would be ignore, but at soon as the running task was done, all the pending tasks status switch to ready instead of staying in pending. 
Now, when we upload a file while a task is pending, it stays pending until the task is processed





**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
