### PR TITLE
Fix default timezone for timestamps in database

### DIFF
--- a/gridcapa-task-manager-app/src/main/resources/application.yml
+++ b/gridcapa-task-manager-app/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
     properties:
         hibernate:
           timezone:
-            default_storage: NORMALIZE
+            default_storage: NORMALIZE_UTC
   sql:
     init:
       mode: always

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskRepositoryTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskRepositoryTest.java
@@ -1,0 +1,27 @@
+package com.farao_community.farao.gridcapa.task_manager.app;
+
+import com.farao_community.farao.gridcapa.task_manager.app.entities.Task;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+@SpringBootTest
+class TaskRepositoryTest {
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @Test
+    void testTimestampPersistence() {
+        //2024 Summer > Winter daylight saving time
+        final OffsetDateTime offsetDateTime = OffsetDateTime.parse("2024-10-27T01:30Z");
+        taskRepository.save(new Task(offsetDateTime));
+        final Optional<Task> persistedTask = taskRepository.findByTimestamp(offsetDateTime);
+        Assertions.assertTrue(persistedTask.isPresent());
+        Assertions.assertEquals(offsetDateTime, persistedTask.get().getTimestamp());
+    }
+}

--- a/gridcapa-task-manager-app/src/test/resources/application.yml
+++ b/gridcapa-task-manager-app/src/test/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     properties:
       hibernate:
         timezone:
-          default_storage: NORMALIZE
+          default_storage: NORMALIZE_UTC
 task-server:
   process:
     tag: CSE_D2CC


### PR DESCRIPTION
Related to issues detailed there : https://thorben-janssen.com/hibernate-6-offsetdatetime-and-zoneddatetime/
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
