### PR TITLE
Adapt task-manager for Core CC needs

### DIFF
--- a/gridcapa-task-manager-api/src/main/java/com/farao_community/farao/gridcapa/task_manager/api/ProcessFileDto.java
+++ b/gridcapa-task-manager-api/src/main/java/com/farao_community/farao/gridcapa/task_manager/api/ProcessFileDto.java
@@ -22,6 +22,7 @@ public class ProcessFileDto {
     private final String fileType;
     private final ProcessFileStatus processFileStatus;
     private final String filename;
+    private final String documentId;
     private final OffsetDateTime lastModificationDate;
 
     @JsonCreator
@@ -29,11 +30,13 @@ public class ProcessFileDto {
                           @JsonProperty("fileType") String fileType,
                           @JsonProperty("processFileStatus") ProcessFileStatus processFileStatus,
                           @JsonProperty("fileName") String filename,
+                          @JsonProperty("documentId") String documentId,
                           @JsonProperty("lastModificationDate") OffsetDateTime lastModificationDate) {
         this.filePath = filePath;
         this.fileType = fileType;
         this.processFileStatus = processFileStatus;
         this.filename = filename;
+        this.documentId = documentId;
         this.lastModificationDate = lastModificationDate;
     }
 
@@ -42,6 +45,7 @@ public class ProcessFileDto {
                 null,
                 fileType,
                 ProcessFileStatus.NOT_PRESENT,
+                null,
                 null,
                 null);
     }
@@ -60,6 +64,10 @@ public class ProcessFileDto {
 
     public String getFilename() {
         return filename;
+    }
+
+    public String getDocumentId() {
+        return documentId;
     }
 
     public OffsetDateTime getLastModificationDate() {

--- a/gridcapa-task-manager-api/src/test/java/com/farao_community/farao/gridcapa/task_manager/api/ProcessFileDtoTest.java
+++ b/gridcapa-task-manager-api/src/test/java/com/farao_community/farao/gridcapa/task_manager/api/ProcessFileDtoTest.java
@@ -26,6 +26,7 @@ class ProcessFileDtoTest {
         assertEquals("CGM", processFileDto.getFileType());
         assertNull(processFileDto.getFilePath());
         assertNull(processFileDto.getFilename());
+        assertNull(processFileDto.getDocumentId());
         assertNull(processFileDto.getLastModificationDate());
         assertEquals(ProcessFileStatus.NOT_PRESENT, processFileDto.getProcessFileStatus());
     }
@@ -33,13 +34,13 @@ class ProcessFileDtoTest {
     @Test
     void testEqualsAndHashCode() {
         OffsetDateTime now = OffsetDateTime.now();
-        ProcessFileDto referenceDto = new ProcessFileDto("path/to/filename", "FILETYPE", ProcessFileStatus.VALIDATED, "filename", now);
-        ProcessFileDto equalDto = new ProcessFileDto("path/to/filename", "FILETYPE", ProcessFileStatus.VALIDATED, "filename", now);
-        ProcessFileDto diffFilePathDto = new ProcessFileDto("other/path/to/filename", "FILETYPE", ProcessFileStatus.VALIDATED, "filename", now);
-        ProcessFileDto diffFileTypeDto = new ProcessFileDto("path/to/filename", "DIFFERENT", ProcessFileStatus.VALIDATED, "filename", now);
-        ProcessFileDto diffStatusDto = new ProcessFileDto("path/to/filename", "FILETYPE", ProcessFileStatus.NOT_PRESENT, "filename", now);
-        ProcessFileDto diffFilenameDto = new ProcessFileDto("path/to/filename", "FILETYPE", ProcessFileStatus.VALIDATED, "other", now);
-        ProcessFileDto diffDateDto = new ProcessFileDto("path/to/filename", "FILETYPE", ProcessFileStatus.VALIDATED, "filename", now.minusMinutes(1));
+        ProcessFileDto referenceDto = new ProcessFileDto("path/to/filename", "FILETYPE", ProcessFileStatus.VALIDATED, "filename", "documentId", now);
+        ProcessFileDto equalDto = new ProcessFileDto("path/to/filename", "FILETYPE", ProcessFileStatus.VALIDATED, "filename", "documentId", now);
+        ProcessFileDto diffFilePathDto = new ProcessFileDto("other/path/to/filename", "FILETYPE", ProcessFileStatus.VALIDATED, "filename", "documentId", now);
+        ProcessFileDto diffFileTypeDto = new ProcessFileDto("path/to/filename", "DIFFERENT", ProcessFileStatus.VALIDATED, "filename", "documentId", now);
+        ProcessFileDto diffStatusDto = new ProcessFileDto("path/to/filename", "FILETYPE", ProcessFileStatus.NOT_PRESENT, "filename", "documentId", now);
+        ProcessFileDto diffFilenameDto = new ProcessFileDto("path/to/filename", "FILETYPE", ProcessFileStatus.VALIDATED, "other", "documentId", now);
+        ProcessFileDto diffDateDto = new ProcessFileDto("path/to/filename", "FILETYPE", ProcessFileStatus.VALIDATED, "filename", "documentId", now.minusMinutes(1));
 
         assertFalse(referenceDto.equals(null)); // do not use assertNotEquals, which does not call equals method in this case
         assertNotEquals(referenceDto, new Object());

--- a/gridcapa-task-manager-api/src/test/java/com/farao_community/farao/gridcapa/task_manager/api/ProcessRunDtoTest.java
+++ b/gridcapa-task-manager-api/src/test/java/com/farao_community/farao/gridcapa/task_manager/api/ProcessRunDtoTest.java
@@ -20,7 +20,7 @@ class ProcessRunDtoTest {
 
     @Test
     void testConstructor() {
-        ProcessFileDto processFileDto = new ProcessFileDto(null, null, null, null, null);
+        ProcessFileDto processFileDto = new ProcessFileDto(null, null, null, null, null, null);
         OffsetDateTime now = OffsetDateTime.now();
         List<ProcessFileDto> inputFiles = List.of(processFileDto);
 

--- a/gridcapa-task-manager-api/src/test/java/com/farao_community/farao/gridcapa/task_manager/api/TaskDtoTest.java
+++ b/gridcapa-task-manager-api/src/test/java/com/farao_community/farao/gridcapa/task_manager/api/TaskDtoTest.java
@@ -37,10 +37,10 @@ class TaskDtoTest {
 
     @Test
     void testConstructor() {
-        ProcessFileDto file1 = new ProcessFileDto("file1", null, null, "file1", null);
-        ProcessFileDto file2 = new ProcessFileDto("file2", null, null, "file2", null);
-        ProcessFileDto file3 = new ProcessFileDto("file3", null, null, "file3", null);
-        ProcessFileDto file4 = new ProcessFileDto("file4", null, null, "file4", null);
+        ProcessFileDto file1 = new ProcessFileDto("file1", null, null, "file1", null, null);
+        ProcessFileDto file2 = new ProcessFileDto("file2", null, null, "file2", null, null);
+        ProcessFileDto file3 = new ProcessFileDto("file3", null, null, "file3", null, null);
+        ProcessFileDto file4 = new ProcessFileDto("file4", null, null, "file4", null, null);
         ProcessEventDto event1 = new ProcessEventDto(null, null, "event1", null);
         ProcessEventDto event2 = new ProcessEventDto(null, null, "event2", null);
         ProcessRunDto run = new ProcessRunDto(null, null);

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerController.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerController.java
@@ -101,10 +101,10 @@ public class TaskManagerController {
     }
 
     @PutMapping(value = "/tasks/{timestamp}/runHistory")
-    public ResponseEntity<TaskDto> addNewRunInTaskHistory(@PathVariable String timestamp) {
+    public ResponseEntity<TaskDto> addNewRunInTaskHistory(@PathVariable String timestamp, @RequestBody List<ProcessFileDto> inputFiles) {
         try {
             synchronized (TASK_MANAGER_LOCK) {
-                Task task = taskService.addNewRunAndSaveTask(OffsetDateTime.parse(timestamp));
+                Task task = taskService.addNewRunAndSaveTask(OffsetDateTime.parse(timestamp), inputFiles);
                 return ResponseEntity.ok(builder.createDtoFromEntity(task));
             }
         } catch (final TaskNotFoundException notFoundException) {

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/entities/ProcessFile.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/entities/ProcessFile.java
@@ -45,6 +45,9 @@ public class ProcessFile implements Comparable<ProcessFile> {
     @Column(name = "file_type")
     private String fileType;
 
+    @Column(name = "document_id")
+    private String documentId;
+
     @Column(name = "starting_availability_date")
     private OffsetDateTime startingAvailabilityDate;
 
@@ -61,6 +64,7 @@ public class ProcessFile implements Comparable<ProcessFile> {
     public ProcessFile(String fileObjectKey,
                        String fileGroup,
                        String fileType,
+                       String documentId,
                        OffsetDateTime startingAvailabilityDate,
                        OffsetDateTime endingAvailabilityDate,
                        OffsetDateTime lastModificationDate) {
@@ -68,6 +72,7 @@ public class ProcessFile implements Comparable<ProcessFile> {
         this.fileObjectKey = fileObjectKey;
         this.fileGroup = fileGroup;
         this.fileType = fileType;
+        this.documentId = documentId;
         this.startingAvailabilityDate = startingAvailabilityDate;
         this.endingAvailabilityDate = endingAvailabilityDate;
         this.lastModificationDate = lastModificationDate;
@@ -87,6 +92,10 @@ public class ProcessFile implements Comparable<ProcessFile> {
 
     public String getFilename() {
         return FilenameUtils.getName(fileObjectKey);
+    }
+
+    public String getDocumentId() {
+        return documentId;
     }
 
     public OffsetDateTime getStartingAvailabilityDate() {
@@ -111,6 +120,10 @@ public class ProcessFile implements Comparable<ProcessFile> {
 
     public void setFileObjectKey(String fileObjectKey) {
         this.fileObjectKey = fileObjectKey;
+    }
+
+    public void setDocumentId(String documentId) {
+        this.documentId = documentId;
     }
 
     public boolean isInputFile() {

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
@@ -160,6 +160,7 @@ public class TaskDtoBuilderService {
                 processFile.getFileType(),
                 ProcessFileStatus.VALIDATED,
                 processFile.getFilename(),
+                processFile.getDocumentId(),
                 processFile.getLastModificationDate());
     }
 

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerControllerTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerControllerTest.java
@@ -233,7 +233,7 @@ class TaskManagerControllerTest {
         String fileType = "CRAC";
         String fakeUrl = "http://fakeUrl";
         Task task = new Task(taskTimestamp);
-        final ProcessFile pf = new ProcessFile("FAKE", "input", fileType, taskTimestamp, taskTimestamp, taskTimestamp);
+        final ProcessFile pf = new ProcessFile("FAKE", "input", fileType, "documentIdCrac", taskTimestamp, taskTimestamp, taskTimestamp);
         task.addProcessFile(pf);
         Mockito.when(taskRepository.findByTimestamp(taskTimestamp)).thenReturn(Optional.of(task));
         Mockito.when(fileManager.openUrlStream(anyString())).thenReturn(InputStream.nullInputStream());
@@ -283,7 +283,7 @@ class TaskManagerControllerTest {
         String fileNameLocalDateTime = taskTimestamp.atZoneSameInstant(ZoneId.of(taskManagerConfigurationProperties.getProcess().getTimezone())).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HHmm"));
         String fileType = "LOGS";
         Task task = new Task(taskTimestamp);
-        final ProcessFile pf = new ProcessFile("FAKE", "input", fileType, taskTimestamp, taskTimestamp, taskTimestamp);
+        final ProcessFile pf = new ProcessFile("FAKE", "input", fileType, null, taskTimestamp, taskTimestamp, taskTimestamp);
         task.addProcessFile(pf);
         Mockito.when(taskRepository.findByTimestamp(taskTimestamp)).thenReturn(Optional.of(task));
         Mockito.when(fileManager.openUrlStream(anyString())).thenReturn(InputStream.nullInputStream());
@@ -302,7 +302,7 @@ class TaskManagerControllerTest {
         String fileNameLocalDateTime = taskTimestamp.atZoneSameInstant(ZoneId.of(taskManagerConfigurationProperties.getProcess().getTimezone())).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HHmm"));
         String fileType = "LOGS";
         Task task = new Task(taskTimestamp);
-        final ProcessFile pf = new ProcessFile("FAKE", "input", fileType, taskTimestamp, taskTimestamp, taskTimestamp);
+        final ProcessFile pf = new ProcessFile("FAKE", "input", fileType, null, taskTimestamp, taskTimestamp, taskTimestamp);
         task.addProcessFile(pf);
         Mockito.when(taskRepository.findByTimestamp(taskTimestamp)).thenReturn(Optional.of(task));
         Mockito.when(fileManager.openUrlStream(anyString())).thenReturn(InputStream.nullInputStream());

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerControllerTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerControllerTest.java
@@ -147,8 +147,8 @@ class TaskManagerControllerTest {
     void testAddNewRunInTaskHistoryOk() {
         OffsetDateTime taskTimestamp = OffsetDateTime.parse("2021-09-30T23:00Z");
         Task task = new Task(taskTimestamp);
-        Mockito.when(taskService.addNewRunAndSaveTask(Mockito.any())).thenReturn(task);
-        ResponseEntity<TaskDto> response = taskManagerController.addNewRunInTaskHistory(taskTimestamp.toString());
+        Mockito.when(taskService.addNewRunAndSaveTask(Mockito.any(), Mockito.any())).thenReturn(task);
+        ResponseEntity<TaskDto> response = taskManagerController.addNewRunInTaskHistory(taskTimestamp.toString(), List.of());
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
         assertEquals(taskTimestamp, response.getBody().getTimestamp());
@@ -157,8 +157,8 @@ class TaskManagerControllerTest {
     @Test
     void testAddNewRunInTaskHistoryThrowsTaskNotFoundException() {
         String timestamp = "2021-09-30T23:00Z";
-        Mockito.when(taskService.addNewRunAndSaveTask(Mockito.any())).thenThrow(TaskNotFoundException.class);
-        ResponseEntity<TaskDto> response = taskManagerController.addNewRunInTaskHistory(timestamp);
+        Mockito.when(taskService.addNewRunAndSaveTask(Mockito.any(), Mockito.any())).thenThrow(TaskNotFoundException.class);
+        ResponseEntity<TaskDto> response = taskManagerController.addNewRunInTaskHistory(timestamp, List.of());
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerTestUtil.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerTestUtil.java
@@ -7,10 +7,10 @@
 package com.farao_community.farao.gridcapa.task_manager.app;
 
 import com.farao_community.farao.gridcapa.task_manager.app.service.MinioHandler;
-import com.farao_community.farao.minio_adapter.starter.MinioAdapter;
 import io.minio.messages.Event;
 import org.mockito.Mockito;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -21,17 +21,23 @@ public final class TaskManagerTestUtil {
     private TaskManagerTestUtil() {
     }
 
-    public static Event createEvent(MinioAdapter minioAdapter, String processTag, String fileGroup, String fileType, String fileKey, String validityInterval) {
+    public static Event createEvent(String processTag, String fileGroup, String fileType, String fileKey, String documentId, String validityInterval) {
         Event event = Mockito.mock(Event.class);
-        Map<String, String> metadata = Map.of(
-                MinioHandler.FILE_GROUP_METADATA_KEY, fileGroup,
-                MinioHandler.FILE_TARGET_PROCESS_METADATA_KEY, processTag,
-                MinioHandler.FILE_TYPE_METADATA_KEY, fileType,
-                MinioHandler.FILE_VALIDITY_INTERVAL_METADATA_KEY, validityInterval
-        );
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(MinioHandler.FILE_GROUP_METADATA_KEY, fileGroup);
+        metadata.put(MinioHandler.FILE_TARGET_PROCESS_METADATA_KEY, processTag);
+        metadata.put(MinioHandler.FILE_TYPE_METADATA_KEY, fileType);
+        metadata.put(MinioHandler.FILE_VALIDITY_INTERVAL_METADATA_KEY, validityInterval);
+        if (null != documentId) {
+            metadata.put(MinioHandler.DOCUMENT_ID_METADATA_KEY, documentId);
+        }
         //The following mock is not use in all test that call this methods. With the "lenient" add you avoid an exception
         Mockito.lenient().when(event.userMetadata()).thenReturn(metadata);
         Mockito.when(event.objectName()).thenReturn(fileKey);
         return event;
+    }
+
+    public static Event createEvent(String processTag, String fileGroup, String fileType, String fileKey, String validityInterval) {
+        return createEvent(processTag, fileGroup, fileType, fileKey, null, validityInterval);
     }
 }

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskProcessFileDeletionTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskProcessFileDeletionTest.java
@@ -64,6 +64,7 @@ class TaskProcessFileDeletionTest {
                 "/CGM",
                 MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE,
                 "CGM",
+                "documentIdCgm",
                 offsetDateTime0,
                 offsetDateTime0.plusHours(1),
                 OffsetDateTime.now());
@@ -73,6 +74,7 @@ class TaskProcessFileDeletionTest {
                 "/CGM2",
                 MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE,
                 "CGM",
+                "documentIdCgm2",
                 offsetDateTime1,
                 offsetDateTime1.plusHours(1),
                 OffsetDateTime.now());
@@ -82,6 +84,7 @@ class TaskProcessFileDeletionTest {
                 "/CGM3",
                 MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE,
                 "CGM",
+                "documentIdCgm3",
                 offsetDateTime2,
                 offsetDateTime2.plusHours(1),
                 OffsetDateTime.now());
@@ -91,6 +94,7 @@ class TaskProcessFileDeletionTest {
                 "/REFPROG",
                 MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE,
                 "REFPROG",
+                "documentIdRefprog",
                 offsetDateTime0,
                 offsetDateTime0.plusHours(4),
                 OffsetDateTime.now());

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskWithOverlappingProcessFilesTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskWithOverlappingProcessFilesTest.java
@@ -57,11 +57,11 @@ class TaskWithOverlappingProcessFilesTest {
 
     @Test
     void checkCorrectFileIsUsedWhenIntervalsOverlap() {
-        Event eventFileInterval1 = TaskManagerTestUtil.createEvent(minioAdapter, "CSE_D2CC", MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE,
+        Event eventFileInterval1 = TaskManagerTestUtil.createEvent("CSE_D2CC", MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE,
                 "File", "File-1",
                 "2020-01-01T22:30Z/2020-12-31T22:30Z");
 
-        Event eventFileInterval2 = TaskManagerTestUtil.createEvent(minioAdapter, "CSE_D2CC", MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE,
+        Event eventFileInterval2 = TaskManagerTestUtil.createEvent("CSE_D2CC", MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE,
                 "File", "File-2",
                 "2020-06-01T22:30Z/2021-06-30T22:30Z");
 
@@ -76,7 +76,7 @@ class TaskWithOverlappingProcessFilesTest {
         assertEquals("File-2", taskInterval2.getInput("File").get().getFilename());
         assertEquals("File-2", taskHavingFileWithOverlappingIntervals.getInput("File").get().getFilename());
 
-        Event eventFile2Deletion = TaskManagerTestUtil.createEvent(minioAdapter, "CSE_D2CC", MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE,
+        Event eventFile2Deletion = TaskManagerTestUtil.createEvent("CSE_D2CC", MinioAdapterConstants.DEFAULT_GRIDCAPA_INPUT_GROUP_METADATA_VALUE,
                 "File", "File-2", "2020-06-01T22:30Z/2021-06-30T22:30Z");
         minioHandler.removeProcessFile(eventFile2Deletion);
         taskHavingFileWithOverlappingIntervals = taskRepository.findByTimestamp(taskTimeStampInBothIntervals).orElseThrow();

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/entities/ProcessFileMinioTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/entities/ProcessFileMinioTest.java
@@ -3,10 +3,9 @@ package com.farao_community.farao.gridcapa.task_manager.app.entities;
 import org.junit.jupiter.api.Test;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProcessFileMinioTest {
 
@@ -16,6 +15,7 @@ class ProcessFileMinioTest {
                 "cgm-name",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -23,10 +23,10 @@ class ProcessFileMinioTest {
                 "cgm-name2",
                 "input",
                 "CGM",
+                "documentIdCgm2",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
-        List<ProcessFileMinio> fileMinioList = new ArrayList<>();
         ProcessFileMinio file1 = new ProcessFileMinio(processFile1, null);
         ProcessFileMinio file2 = new ProcessFileMinio(processFile2, null);
         assertTrue(file1.hasSameTypeAndValidity(file1));
@@ -41,6 +41,7 @@ class ProcessFileMinioTest {
                 "cgm-name",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -48,6 +49,7 @@ class ProcessFileMinioTest {
                 "cgm-name2",
                 "input",
                 "CGM",
+                "documentIdCgm2",
                 OffsetDateTime.parse("2021-10-11T00:01Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -55,6 +57,7 @@ class ProcessFileMinioTest {
                 "cgm-name2",
                 "input",
                 "CGM",
+                "documentIdCgm2",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:02Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -62,10 +65,10 @@ class ProcessFileMinioTest {
                 "cgm-name2",
                 "input",
                 "CRAC",
+                "documentIdCrac",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
-        List<ProcessFileMinio> fileMinioList = new ArrayList<>();
         ProcessFileMinio file1 = new ProcessFileMinio(processFile1, null);
         ProcessFileMinio file2 = new ProcessFileMinio(processFile2, null);
         ProcessFileMinio file3 = new ProcessFileMinio(processFile3, null);

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/entities/ProcessFileTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/entities/ProcessFileTest.java
@@ -26,6 +26,7 @@ class ProcessFileTest {
                 "cgm-name",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -39,6 +40,7 @@ class ProcessFileTest {
                 "file-name",
                 "output",
                 "CNE",
+                null,
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -47,6 +49,7 @@ class ProcessFileTest {
                 "file-name",
                 "artifact",
                 "RANDOM",
+                null,
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -61,6 +64,7 @@ class ProcessFileTest {
                 "file-name",
                 "output",
                 "CNE",
+                null,
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -74,6 +78,7 @@ class ProcessFileTest {
                 "cgm-name",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -82,6 +87,7 @@ class ProcessFileTest {
                 "file-name",
                 "artifact",
                 "RANDOM",
+                null,
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -96,6 +102,7 @@ class ProcessFileTest {
                 "cgm-name",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -103,6 +110,7 @@ class ProcessFileTest {
                 "cgm-name2",
                 "input",
                 "CGM",
+                "documentIdCgm2",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -110,6 +118,7 @@ class ProcessFileTest {
                 "cgm-name3",
                 "input",
                 "CGM",
+                "documentIdCgm3",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-24T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -124,6 +133,7 @@ class ProcessFileTest {
                 "cgm-name1",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -131,6 +141,7 @@ class ProcessFileTest {
                 "cgm-name2",
                 "input",
                 "CRAC",
+                "documentIdCrac",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -138,6 +149,7 @@ class ProcessFileTest {
                 "cgm-name3",
                 "output",
                 "CGM",
+                "documentIdCgm3",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -145,6 +157,7 @@ class ProcessFileTest {
                 "cgm-name4",
                 "input",
                 "CGM",
+                "documentIdCgm4",
                 OffsetDateTime.parse("2021-10-11T12:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -152,6 +165,7 @@ class ProcessFileTest {
                 "cgm-name5",
                 "input",
                 "CGM",
+                "documentIdCgm5",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:30Z"));
@@ -168,6 +182,7 @@ class ProcessFileTest {
                 "cgm-name",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -175,6 +190,7 @@ class ProcessFileTest {
                 "cgm-name2",
                 "input",
                 "CGM",
+                "documentIdCgm2",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -182,6 +198,7 @@ class ProcessFileTest {
                 "cgm-name3",
                 "input",
                 "CGM",
+                "documentIdCgm3",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-24T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -197,6 +214,7 @@ class ProcessFileTest {
                 "cgm-name1",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -204,6 +222,7 @@ class ProcessFileTest {
                 "cgm-name2",
                 "input",
                 "CRAC",
+                "documentIdCrac",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -211,6 +230,7 @@ class ProcessFileTest {
                 "cgm-name3",
                 "output",
                 "CGM",
+                "documentIdCgm3",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -218,6 +238,7 @@ class ProcessFileTest {
                 "cgm-name4",
                 "input",
                 "CGM",
+                "documentIdCgm4",
                 OffsetDateTime.parse("2021-10-11T12:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -225,6 +246,7 @@ class ProcessFileTest {
                 "cgm-name5",
                 "input",
                 "CGM",
+                "documentIdCgm5",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:30Z"));

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/entities/ProcessRunTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/entities/ProcessRunTest.java
@@ -43,8 +43,8 @@ class ProcessRunTest {
     @Test
     void removeInputFileByFilenameTest() {
         OffsetDateTime now = OffsetDateTime.now();
-        ProcessFile file1 = new ProcessFile("first-file", "input", "CGM", now, now, now);
-        ProcessFile file2 = new ProcessFile("second-file", "input", "CGM", now, now, now);
+        ProcessFile file1 = new ProcessFile("first-file", "input", "CGM", "documentIdCgm", now, now, now);
+        ProcessFile file2 = new ProcessFile("second-file", "input", "CGM", "documentIdCgm2", now, now, now);
         ProcessRun processRun = new ProcessRun(List.of(file1, file2));
 
         Assertions.assertThat(processRun.getInputFiles()).isNotNull().containsExactly(file1, file2);

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/entities/TaskTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/entities/TaskTest.java
@@ -56,6 +56,7 @@ class TaskTest {
                 "cne-file",
                 "output",
                 "CNE",
+                null,
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -78,6 +79,7 @@ class TaskTest {
                 "ttc-file",
                 "output",
                 "TTC",
+                null,
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:20Z"));
@@ -95,6 +97,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -123,6 +126,7 @@ class TaskTest {
                 "CRAC-file",
                 "input",
                 "CRAC",
+                "documentIdCrac",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:20Z"));
@@ -146,6 +150,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -164,6 +169,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T22:20Z"));
@@ -184,6 +190,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -202,6 +209,7 @@ class TaskTest {
                 "other-cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm2",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T12:20Z"));
@@ -233,6 +241,7 @@ class TaskTest {
                 "cne-file",
                 "output",
                 "CNE",
+                null,
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -240,6 +249,7 @@ class TaskTest {
                 "ttc-file",
                 "output",
                 "TTC",
+                null,
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:20Z"));
@@ -265,6 +275,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -272,6 +283,7 @@ class TaskTest {
                 "other-cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm2",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T12:20Z"));
@@ -300,6 +312,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -307,6 +320,7 @@ class TaskTest {
                 "other-cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm2",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T12:20Z"));
@@ -314,6 +328,7 @@ class TaskTest {
                 "other-cgm-file-again",
                 "input",
                 "CGM",
+                "documentIdCgm3",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T14:42Z"));
@@ -344,6 +359,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -367,6 +383,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -388,6 +405,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -395,6 +413,7 @@ class TaskTest {
                 "other-cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm2",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T12:20Z"));
@@ -421,6 +440,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -428,6 +448,7 @@ class TaskTest {
                 "cne-file",
                 "output",
                 "CNE",
+                null,
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -444,6 +465,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -454,6 +476,7 @@ class TaskTest {
                 "glsk-file",
                 "input",
                 "GLSK",
+                "documentIdGlsk",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -468,6 +491,7 @@ class TaskTest {
                 "other-cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm2",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T22:20Z"));
@@ -486,6 +510,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -493,6 +518,7 @@ class TaskTest {
                 "cne-file",
                 "output",
                 "CNE",
+                null,
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -517,6 +543,7 @@ class TaskTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/FileSelectorServiceTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/FileSelectorServiceTest.java
@@ -69,8 +69,8 @@ class FileSelectorServiceTest {
     @Test
     void selectFileWithStatusReset() {
         OffsetDateTime now = OffsetDateTime.now();
-        ProcessFile processFile1 = new ProcessFile("path/to/crac-file", "input", "CRAC", now, now, now);
-        ProcessFile processFile2 = new ProcessFile("path/to/other-crac-file", "input", "CRAC", now, now, now);
+        ProcessFile processFile1 = new ProcessFile("path/to/crac-file", "input", "CRAC", "documentIdCrac", now, now, now);
+        ProcessFile processFile2 = new ProcessFile("path/to/other-crac-file", "input", "CRAC", "documentIdCrac2", now, now, now);
         Task task = new Task(now);
         task.setStatus(TaskStatus.SUCCESS);
         task.addProcessFile(processFile1);
@@ -90,8 +90,8 @@ class FileSelectorServiceTest {
     @Test
     void selectFileWithoutStatusReset() {
         OffsetDateTime now = OffsetDateTime.now();
-        ProcessFile processFile1 = new ProcessFile("path/to/crac-file", "input", "CRAC", now, now, now);
-        ProcessFile processFile2 = new ProcessFile("path/to/other-crac-file", "input", "CRAC", now, now, now);
+        ProcessFile processFile1 = new ProcessFile("path/to/crac-file", "input", "CRAC", "documentIdCrac", now, now, now);
+        ProcessFile processFile2 = new ProcessFile("path/to/other-crac-file", "input", "CRAC", "documentIdCrac2", now, now, now);
         Task task = new Task(now);
         task.setStatus(TaskStatus.READY);
         task.addProcessFile(processFile1);

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
@@ -110,6 +110,7 @@ class TaskDtoBuilderServiceTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 timestamp,
                 timestamp.plusHours(1),
                 timestamp);
@@ -117,6 +118,7 @@ class TaskDtoBuilderServiceTest {
                 "cne-file",
                 "output",
                 "CNE",
+                null,
                 timestamp,
                 timestamp.plusHours(1),
                 timestamp);
@@ -151,6 +153,7 @@ class TaskDtoBuilderServiceTest {
                 "cgm-file",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 timestamp,
                 timestamp.plusHours(1),
                 timestamp);
@@ -158,6 +161,7 @@ class TaskDtoBuilderServiceTest {
                 "cne-file",
                 "output",
                 "CNE",
+                null,
                 timestamp,
                 timestamp.plusHours(1),
                 timestamp);
@@ -185,24 +189,27 @@ class TaskDtoBuilderServiceTest {
 
     @Test
     void createDtoFromEntityProcessFileTest() {
-        String fileType = "CGM";
-        String filename = "cgm-name";
-        String filePath = "path/to/" + filename;
-        OffsetDateTime modificationDate = OffsetDateTime.parse("2021-10-11T10:18Z");
-        ProcessFile processFile = new ProcessFile(
+        final String fileType = "CGM";
+        final String filename = "cgm-name";
+        final String filePath = "path/to/" + filename;
+        final String documentId = "documentIdCgm";
+        final OffsetDateTime modificationDate = OffsetDateTime.parse("2021-10-11T10:18Z");
+        final ProcessFile processFile = new ProcessFile(
                 filePath,
                 "input",
                 fileType,
+                documentId,
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 modificationDate);
 
-        ProcessFileDto processFileDto = taskDtoBuilderService.createDtoFromEntity(processFile);
+        final ProcessFileDto processFileDto = taskDtoBuilderService.createDtoFromEntity(processFile);
 
         Assertions.assertThat(processFileDto).isNotNull();
         Assertions.assertThat(processFileDto.getFileType()).isEqualTo(fileType);
         Assertions.assertThat(processFileDto.getFilePath()).isEqualTo(filePath);
         Assertions.assertThat(processFileDto.getFilename()).isEqualTo(filename);
+        Assertions.assertThat(processFileDto.getDocumentId()).isEqualTo(documentId);
         Assertions.assertThat(processFileDto.getProcessFileStatus()).isEqualTo(ProcessFileStatus.VALIDATED);
         Assertions.assertThat(processFileDto.getLastModificationDate()).isEqualTo(modificationDate);
     }
@@ -225,8 +232,8 @@ class TaskDtoBuilderServiceTest {
 
     @Test
     void createDtoFromEntityProcessRunTest() {
-        ProcessFile processFile1 = new ProcessFile("path/to/file-name", "input", "CGM", OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now());
-        ProcessFile processFile2 = new ProcessFile("path/to/other-file-name", "input", "GLSK", OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now());
+        ProcessFile processFile1 = new ProcessFile("path/to/file-name", "input", "CGM", "documentIdCgm", OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now());
+        ProcessFile processFile2 = new ProcessFile("path/to/other-file-name", "input", "GLSK", "documentIdGlsk", OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now());
         ProcessRun processRun = new ProcessRun(List.of(processFile1, processFile2));
 
         ProcessRunDto processRunDto = taskDtoBuilderService.createDtoFromEntity(processRun);

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskServiceTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskServiceTest.java
@@ -80,9 +80,9 @@ class TaskServiceTest {
         OffsetDateTime timestamp = OffsetDateTime.now();
         Task task = new Task();
         task.setStatus(TaskStatus.CREATED);
-        ProcessFile cgmFile = new ProcessFile("file1", "input", "CGM", timestamp, timestamp, timestamp);
+        ProcessFile cgmFile = new ProcessFile("file1", "input", "CGM", "documentIdCgm", timestamp, timestamp, timestamp);
         task.addProcessFile(cgmFile);
-        ProcessFile cracFile = new ProcessFile("file2", "input", "CRAC", timestamp, timestamp, timestamp);
+        ProcessFile cracFile = new ProcessFile("file2", "input", "CRAC", "documentIdCrac", timestamp, timestamp, timestamp);
         task.addProcessFile(cracFile);
 
         Assertions.assertThat(task.getStatus()).isEqualTo(TaskStatus.CREATED);
@@ -99,9 +99,9 @@ class TaskServiceTest {
         Task task = new Task();
         TaskStatus initialTaskStatus = TaskStatus.SUCCESS;
         task.setStatus(initialTaskStatus);
-        ProcessFile cgmFile = new ProcessFile("file1", "input", "CGM", timestamp, timestamp, timestamp);
+        ProcessFile cgmFile = new ProcessFile("file1", "input", "CGM", "documentIdCgm", timestamp, timestamp, timestamp);
         task.addProcessFile(cgmFile);
-        ProcessFile cracFile = new ProcessFile("file2", "input", "CRAC", timestamp, timestamp, timestamp);
+        ProcessFile cracFile = new ProcessFile("file2", "input", "CRAC", "documentIdCrac", timestamp, timestamp, timestamp);
         task.addProcessFile(cracFile);
 
         boolean statusChanged = taskService.checkAndUpdateTaskStatus(task, false);
@@ -116,7 +116,7 @@ class TaskServiceTest {
         Task task = new Task();
         TaskStatus initialTaskStatus = TaskStatus.SUCCESS;
         task.setStatus(initialTaskStatus);
-        ProcessFile cgmFile = new ProcessFile("file1", "input", "CGM", timestamp, timestamp, timestamp);
+        ProcessFile cgmFile = new ProcessFile("file1", "input", "CGM", "documentIdCgm", timestamp, timestamp, timestamp);
         task.addProcessFile(cgmFile);
 
         boolean statusChanged = taskService.checkAndUpdateTaskStatus(task, false);
@@ -131,7 +131,7 @@ class TaskServiceTest {
         Task task = new Task();
         TaskStatus initialTaskStatus = TaskStatus.SUCCESS;
         task.setStatus(initialTaskStatus);
-        ProcessFile cgmFile = new ProcessFile("file1", "input", "CGM", timestamp, timestamp, timestamp);
+        ProcessFile cgmFile = new ProcessFile("file1", "input", "CGM", "documentIdCgm", timestamp, timestamp, timestamp);
         task.addProcessFile(cgmFile);
 
         boolean statusChanged = taskService.checkAndUpdateTaskStatus(task, true);
@@ -185,6 +185,7 @@ class TaskServiceTest {
                 "path/MANUAL_UPLOAD/to/cgm-file.xml",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -202,6 +203,7 @@ class TaskServiceTest {
                 "path/to/cgm-file.xml",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -219,6 +221,7 @@ class TaskServiceTest {
                 "path/to/cgm-file.xml",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -236,6 +239,7 @@ class TaskServiceTest {
                 "path/to/cgm-file.xml",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -253,6 +257,7 @@ class TaskServiceTest {
                 "path/to/cgm-file.xml",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -271,6 +276,7 @@ class TaskServiceTest {
                 "path/to/cgm-file.xml",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T00:00Z"),
                 OffsetDateTime.parse("2021-10-12T00:00Z"),
                 OffsetDateTime.parse("2021-10-11T10:18Z"));
@@ -294,6 +300,7 @@ class TaskServiceTest {
                 "path/to/cne-file.xml",
                 "output",
                 "CNE",
+                null,
                 OffsetDateTime.parse("2021-10-11T01:00Z"),
                 OffsetDateTime.parse("2021-10-11T04:00Z"),
                 OffsetDateTime.parse("2021-10-11T00:18Z"));
@@ -324,6 +331,7 @@ class TaskServiceTest {
                 "path/to/cgm-file.xml",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T01:00Z"),
                 OffsetDateTime.parse("2021-10-11T03:00Z"),
                 OffsetDateTime.parse("2021-10-11T00:18Z"));
@@ -331,6 +339,7 @@ class TaskServiceTest {
                 "path/to/crac-file.xml",
                 "input",
                 "CRAC",
+                "documentIdCrac",
                 OffsetDateTime.parse("2021-10-11T01:00Z"),
                 OffsetDateTime.parse("2021-10-11T03:00Z"),
                 OffsetDateTime.parse("2021-10-11T00:18Z"));
@@ -338,6 +347,7 @@ class TaskServiceTest {
                 "path/to/crac-file.xml",
                 "input",
                 "CRAC",
+                "documentIdCrac",
                 OffsetDateTime.parse("2021-10-11T01:00Z"),
                 OffsetDateTime.parse("2021-10-11T03:00Z"),
                 OffsetDateTime.parse("2021-10-11T00:45Z"));
@@ -372,6 +382,7 @@ class TaskServiceTest {
                 "path/to/cgm-file.xml",
                 "input",
                 "CGM",
+                "documentIdCgm",
                 OffsetDateTime.parse("2021-10-11T01:00Z"),
                 OffsetDateTime.parse("2021-10-11T03:00Z"),
                 OffsetDateTime.parse("2021-10-11T00:18Z"));
@@ -379,6 +390,7 @@ class TaskServiceTest {
                 "path/to/crac-file.xml",
                 "input",
                 "CRAC",
+                "documentIdCrac",
                 OffsetDateTime.parse("2021-10-11T01:00Z"),
                 OffsetDateTime.parse("2021-10-11T03:00Z"),
                 OffsetDateTime.parse("2021-10-11T00:18Z"));
@@ -386,6 +398,7 @@ class TaskServiceTest {
                 "path/to/crac-file.xml",
                 "input",
                 "CRAC",
+                "documentIdCrac",
                 OffsetDateTime.parse("2021-10-11T01:00Z"),
                 OffsetDateTime.parse("2021-10-11T03:00Z"),
                 OffsetDateTime.parse("2021-10-11T00:45Z"));
@@ -426,6 +439,7 @@ class TaskServiceTest {
                 "path/to/glsk-file.xml",
                 "input",
                 "GLSK",
+                "documentIdGlsk",
                 startingDate,
                 endingDate,
                 startingDate);
@@ -433,6 +447,7 @@ class TaskServiceTest {
                 "path/to/crac-file.xml",
                 "input",
                 "CRAC",
+                "documentIdCrac",
                 startingDate,
                 endingDate,
                 startingDate);
@@ -467,6 +482,7 @@ class TaskServiceTest {
                 "path/to/glsk-file.xml",
                 "input",
                 "GLSK",
+                "documentIdGlsk",
                 startingDate,
                 endingDate,
                 startingDate);
@@ -474,6 +490,7 @@ class TaskServiceTest {
                 "path/to/crac-file.xml",
                 "input",
                 "CRAC",
+                "documentIdCrac",
                 startingDate,
                 endingDate,
                 startingDate);
@@ -508,6 +525,7 @@ class TaskServiceTest {
                 "path/to/crac-file.xml",
                 "input",
                 "CRAC",
+                "documentIdCrac",
                 startingDate,
                 endingDate,
                 startingDate);
@@ -537,6 +555,7 @@ class TaskServiceTest {
                 "path/to/glsk-file.xml",
                 "input",
                 "GLSK",
+                "documentIdGlsk",
                 startingDate,
                 endingDate,
                 startingDate);
@@ -544,6 +563,7 @@ class TaskServiceTest {
                 "path/to/cne-file.xml",
                 "input",
                 "CNE",
+                null,
                 startingDate,
                 endingDate,
                 startingDate);
@@ -609,11 +629,11 @@ class TaskServiceTest {
         OffsetDateTime timestamp = OffsetDateTime.now();
         Task task = new Task();
         task.setStatus(taskStatus);
-        ProcessFile processFile1 = new ProcessFile("file1", "input", "CGM", timestamp, timestamp, timestamp);
+        ProcessFile processFile1 = new ProcessFile("file1", "input", "CGM", "documentIdCgm", timestamp, timestamp, timestamp);
         task.addProcessFile(processFile1);
-        ProcessFile processFile2 = new ProcessFile("file2", "input", "CRAC", timestamp, timestamp, timestamp);
+        ProcessFile processFile2 = new ProcessFile("file2", "input", "CRAC", "documentIdCrac", timestamp, timestamp, timestamp);
         task.addProcessFile(processFile2);
-        ProcessFile processFile3 = new ProcessFile("file3", "input", "CRAC", timestamp, timestamp, timestamp);
+        ProcessFile processFile3 = new ProcessFile("file3", "input", "CRAC", "documentIdCrac", timestamp, timestamp, timestamp);
         task.addProcessFile(processFile3);
         Mockito.when(taskRepository.findByTimestamp(Mockito.any())).thenReturn(Optional.of(task));
 
@@ -643,9 +663,9 @@ class TaskServiceTest {
     void addNewRunAndSaveTaskOk() {
         OffsetDateTime timestamp = OffsetDateTime.now();
         Task task = new Task();
-        ProcessFile processFile1 = new ProcessFile("file1", "input", "CGM", timestamp, timestamp, timestamp);
+        ProcessFile processFile1 = new ProcessFile("file1", "input", "CGM", "documentIdCgm", timestamp, timestamp, timestamp);
         task.addProcessFile(processFile1);
-        ProcessFile processFile2 = new ProcessFile("file2", "input", "CRAC", timestamp, timestamp, timestamp);
+        ProcessFile processFile2 = new ProcessFile("file2", "input", "CRAC", "documentIdCrac", timestamp, timestamp, timestamp);
         task.addProcessFile(processFile2);
         Mockito.when(taskRepository.findByTimestamp(Mockito.any())).thenReturn(Optional.of(task));
         Mockito.when(taskRepository.save(task)).thenReturn(task);
@@ -661,8 +681,8 @@ class TaskServiceTest {
     @ParameterizedTest
     @EnumSource(value = FileEventType.class, names = {"AVAILABLE", "WAITING"})
     void removeUnavailableProcessFileFromTaskRunHistoryWithBadFileEventType(FileEventType fileEventType) {
-        ProcessFile processFile1 = new ProcessFile("path/to/file-name", "input", "CGM", OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now());
-        ProcessFile processFile2 = new ProcessFile("path/to/other-file-name", "input", "GLSK", OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now());
+        ProcessFile processFile1 = new ProcessFile("path/to/file-name", "input", "CGM", "documentIdCgm", OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now());
+        ProcessFile processFile2 = new ProcessFile("path/to/other-file-name", "input", "GLSK", "documentIdGlsk", OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now());
         ProcessRun processRun = new ProcessRun(List.of(processFile1, processFile2));
         Task task = new Task(OffsetDateTime.now());
         task.addProcessFile(processFile1);
@@ -679,8 +699,8 @@ class TaskServiceTest {
     @ParameterizedTest
     @EnumSource(value = FileEventType.class, names = {"UPDATED", "DELETED"})
     void removeUnavailableProcessFileFromTaskRunHistoryWithGoodFileEventType(FileEventType fileEventType) {
-        ProcessFile processFile1 = new ProcessFile("path/to/file-name", "input", "CGM", OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now());
-        ProcessFile processFile2 = new ProcessFile("path/to/other-file-name", "input", "GLSK", OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now());
+        ProcessFile processFile1 = new ProcessFile("path/to/file-name", "input", "CGM", "documentIdCgm", OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now());
+        ProcessFile processFile2 = new ProcessFile("path/to/other-file-name", "input", "GLSK", "documentIdGlsk", OffsetDateTime.now(), OffsetDateTime.now(), OffsetDateTime.now());
         ProcessRun processRun = new ProcessRun(List.of(processFile1, processFile2));
         Task task = new Task(OffsetDateTime.now());
         task.addProcessFile(processFile1);

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <properties>
         <!-- Dependency versions -->
         <apache.commons.verion>2.11.0</apache.commons.verion>
-        <gridcapa.starter.minio.adapter.version>1.2.0-SNAPSHOT</gridcapa.starter.minio.adapter.version>
+        <gridcapa.starter.minio.adapter.version>1.2.0</gridcapa.starter.minio.adapter.version>
         <postgres.jdbc.version>42.3.9</postgres.jdbc.version>
         <logstash.version>7.0.1</logstash.version>
         <liquibase.version>4.28.0</liquibase.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <properties>
         <!-- Dependency versions -->
         <apache.commons.verion>2.11.0</apache.commons.verion>
-        <gridcapa.starter.minio.adapter.version>1.1.2</gridcapa.starter.minio.adapter.version>
+        <gridcapa.starter.minio.adapter.version>1.2.0-SNAPSHOT</gridcapa.starter.minio.adapter.version>
         <postgres.jdbc.version>42.3.9</postgres.jdbc.version>
         <logstash.version>7.0.1</logstash.version>
         <liquibase.version>4.28.0</liquibase.version>


### PR DESCRIPTION
Some adaptations to make it possible for Core CC process to use input files listed in F302 file instead of selected ones :
- Add DocumentId attribute to ProcessFile ;
- Change the way ProcessRun is created by using input files from the request instead of using selected files from the task.


**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
