### PR TITLE
Fix the addition of ProcessRun to the task's history by searching the files in both inputFiles and availableInputFiles lists

### DIFF
--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskService.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskService.java
@@ -235,7 +235,10 @@ public class TaskService {
     }
 
     private static ProcessFile getProcessFileFromTaskMatchingDto(Task task, ProcessFileDto processFileDto) {
-        return task.getAvailableInputs(processFileDto.getFileType()).stream()
+        return Stream.concat(
+                        task.getAvailableInputs(processFileDto.getFileType()).stream(),
+                        task.getInput(processFileDto.getFileType()).stream()
+                )
                 .filter(f -> f.getFilename().equals(processFileDto.getFilename()))
                 .findAny()
                 .orElseThrow(ProcessFileNotFoundException::new);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
