### PR TITLE
Proposed change to 'is all over' method for post-processing

### DIFF
--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerController.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerController.java
@@ -175,9 +175,9 @@ public class TaskManagerController {
     }
 
     @GetMapping(value = "/tasks/businessdate/{businessDate}/allOver")
-    public ResponseEntity<Boolean> areAllTasksFromBusinessDateOver(@PathVariable String businessDate) {
+    public ResponseEntity<Boolean> areAllTasksFromBusinessDateOver(@PathVariable final String businessDate) {
         return ResponseEntity.ok().body(
-                builder.getTasksStatusAllOverForPostProcessing(LocalDate.parse(businessDate)));
+                builder.areAllTasksOverForBusinessDate(LocalDate.parse(businessDate)));
     }
 
     @GetMapping(value = "/tasks/runningtasks")

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerController.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerController.java
@@ -177,9 +177,7 @@ public class TaskManagerController {
     @GetMapping(value = "/tasks/businessdate/{businessDate}/allOver")
     public ResponseEntity<Boolean> areAllTasksFromBusinessDateOver(@PathVariable String businessDate) {
         return ResponseEntity.ok().body(
-                builder.getListTasksDto(LocalDate.parse(businessDate))
-                        .stream().map(TaskDto::getStatus)
-                        .allMatch(TaskStatus::isOver));
+                builder.getTasksStatusAllOverForPostProcessing(LocalDate.parse(businessDate)));
     }
 
     @GetMapping(value = "/tasks/runningtasks")

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/configuration/TaskManagerConfigurationProperties.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/configuration/TaskManagerConfigurationProperties.java
@@ -46,9 +46,10 @@ public class TaskManagerConfigurationProperties {
         private final List<String> availableInputs;
         private final List<String> outputs;
         private final boolean enableExportLogs;
+        private final boolean isOnTheHourProcess;
         private final String manualUploadBasePath;
 
-        public ProcessProperties(String tag, String timezone, List<String> inputs, List<String> optionalInputs, final List<String> availableInputs, List<String> outputs, boolean enableExportLogs, String manualUploadBasePath) {
+        public ProcessProperties(String tag, String timezone, List<String> inputs, List<String> optionalInputs, final List<String> availableInputs, List<String> outputs, boolean enableExportLogs, boolean isOnTheHourProcess, String manualUploadBasePath) {
             this.tag = tag;
             this.timezone = timezone;
             this.inputs = inputs;
@@ -56,6 +57,7 @@ public class TaskManagerConfigurationProperties {
             this.availableInputs = availableInputs;
             this.outputs = outputs;
             this.enableExportLogs = enableExportLogs;
+            this.isOnTheHourProcess = isOnTheHourProcess;
             this.manualUploadBasePath = manualUploadBasePath;
         }
 
@@ -85,6 +87,10 @@ public class TaskManagerConfigurationProperties {
 
         public String getManualUploadBasePath() {
             return manualUploadBasePath;
+        }
+
+        public boolean isOnTheHourProcess() {
+            return isOnTheHourProcess;
         }
 
         public List<String> getAvailableInputs() {

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/configuration/TaskManagerConfigurationProperties.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/configuration/TaskManagerConfigurationProperties.java
@@ -21,7 +21,7 @@ public class TaskManagerConfigurationProperties {
     private final List<String> whitelist;
     public static final Object TASK_MANAGER_LOCK = new Object();
 
-    public TaskManagerConfigurationProperties(ProcessProperties process, List<String> whitelist) {
+    public TaskManagerConfigurationProperties(final ProcessProperties process, final List<String> whitelist) {
         this.process = process;
         this.whitelist = whitelist;
     }
@@ -49,7 +49,15 @@ public class TaskManagerConfigurationProperties {
         private final boolean isOnTheHourProcess;
         private final String manualUploadBasePath;
 
-        public ProcessProperties(String tag, String timezone, List<String> inputs, List<String> optionalInputs, final List<String> availableInputs, List<String> outputs, boolean enableExportLogs, boolean isOnTheHourProcess, String manualUploadBasePath) {
+        public ProcessProperties(final String tag,
+                                 final String timezone,
+                                 final List<String> inputs,
+                                 final List<String> optionalInputs,
+                                 final List<String> availableInputs,
+                                 final List<String> outputs,
+                                 final boolean enableExportLogs,
+                                 final boolean isOnTheHourProcess,
+                                 final String manualUploadBasePath) {
             this.tag = tag;
             this.timezone = timezone;
             this.inputs = inputs;

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepository.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepository.java
@@ -59,10 +59,10 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
     @Query("SELECT task FROM Task task JOIN FETCH task.processFiles " +
             "WHERE task.timestamp >= :startingTimestamp AND task.timestamp <= :endingTimestamp")
     Set<Task> findAllByTimestampBetweenForBusinessDayView(@Param("startingTimestamp") OffsetDateTime startingTimestamp,
-                                        @Param("endingTimestamp") OffsetDateTime endingTimestamp);
+                                                          @Param("endingTimestamp") OffsetDateTime endingTimestamp);
 
     @Query("SELECT DISTINCT task.status FROM Task task " +
            "WHERE task.timestamp >= :startingTimestamp AND task.timestamp <= :endingTimestamp")
     Set<TaskStatus> findTaskStatusByTimestampBetween(@Param("startingTimestamp") final OffsetDateTime startingTimestamp,
-                                                      @Param("endingTimestamp") final OffsetDateTime endingTimestamp);
+                                                     @Param("endingTimestamp") final OffsetDateTime endingTimestamp);
 }

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepository.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepository.java
@@ -64,5 +64,5 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
     @Query("SELECT DISTINCT task.status FROM Task task " +
            "WHERE task.timestamp >= :startingTimestamp AND task.timestamp <= :endingTimestamp")
     Set<TaskStatus> findTaskStatusesByTimestampBetween(@Param("startingTimestamp") final OffsetDateTime startingTimestamp,
-                                                     @Param("endingTimestamp") final OffsetDateTime endingTimestamp);
+                                                       @Param("endingTimestamp") final OffsetDateTime endingTimestamp);
 }

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepository.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepository.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.OffsetDateTime;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -61,4 +62,8 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
     Set<Task> findAllByTimestampBetweenForBusinessDayView(@Param("startingTimestamp") OffsetDateTime startingTimestamp,
                                         @Param("endingTimestamp") OffsetDateTime endingTimestamp);
 
+    @Query("SELECT task.status FROM Task task " +
+           "WHERE task.timestamp >= :startingTimestamp AND task.timestamp <= :endingTimestamp")
+    List<TaskStatus> findTaskStatusByTimestampBetweenForPostProcessor(@Param("startingTimestamp") OffsetDateTime startingTimestamp,
+                                                                             @Param("endingTimestamp") OffsetDateTime endingTimestamp);
 }

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepository.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepository.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Repository;
 
 import java.time.OffsetDateTime;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -62,8 +61,8 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
     Set<Task> findAllByTimestampBetweenForBusinessDayView(@Param("startingTimestamp") OffsetDateTime startingTimestamp,
                                         @Param("endingTimestamp") OffsetDateTime endingTimestamp);
 
-    @Query("SELECT task.status FROM Task task " +
+    @Query("SELECT DISTINCT task.status FROM Task task " +
            "WHERE task.timestamp >= :startingTimestamp AND task.timestamp <= :endingTimestamp")
-    List<TaskStatus> findTaskStatusByTimestampBetween(@Param("startingTimestamp") final OffsetDateTime startingTimestamp,
+    Set<TaskStatus> findTaskStatusByTimestampBetween(@Param("startingTimestamp") final OffsetDateTime startingTimestamp,
                                                       @Param("endingTimestamp") final OffsetDateTime endingTimestamp);
 }

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepository.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepository.java
@@ -63,6 +63,6 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
 
     @Query("SELECT DISTINCT task.status FROM Task task " +
            "WHERE task.timestamp >= :startingTimestamp AND task.timestamp <= :endingTimestamp")
-    Set<TaskStatus> findTaskStatusByTimestampBetween(@Param("startingTimestamp") final OffsetDateTime startingTimestamp,
+    Set<TaskStatus> findTaskStatusesByTimestampBetween(@Param("startingTimestamp") final OffsetDateTime startingTimestamp,
                                                      @Param("endingTimestamp") final OffsetDateTime endingTimestamp);
 }

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepository.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepository.java
@@ -64,6 +64,6 @@ public interface TaskRepository extends JpaRepository<Task, UUID> {
 
     @Query("SELECT task.status FROM Task task " +
            "WHERE task.timestamp >= :startingTimestamp AND task.timestamp <= :endingTimestamp")
-    List<TaskStatus> findTaskStatusByTimestampBetweenForPostProcessor(@Param("startingTimestamp") OffsetDateTime startingTimestamp,
-                                                                             @Param("endingTimestamp") OffsetDateTime endingTimestamp);
+    List<TaskStatus> findTaskStatusByTimestampBetween(@Param("startingTimestamp") final OffsetDateTime startingTimestamp,
+                                                      @Param("endingTimestamp") final OffsetDateTime endingTimestamp);
 }

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
@@ -101,7 +101,7 @@ public class TaskDtoBuilderService {
     public boolean areAllTasksOverForBusinessDate(final LocalDate businessDate) {
         final OffsetDateTime startTimestamp = getDateAtOffset(businessDate.atTime(0, 0));
         final OffsetDateTime endTimestamp = getDateAtOffset(businessDate.atTime(23, 59));
-        final List<TaskStatus> statuses = taskRepository.findTaskStatusByTimestampBetween(startTimestamp, endTimestamp);
+        final Set<TaskStatus> statuses = taskRepository.findTaskStatusByTimestampBetween(startTimestamp, endTimestamp);
         return statuses.stream().allMatch(TaskStatus::isOver);
     }
 

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
@@ -12,6 +12,7 @@ import com.farao_community.farao.gridcapa.task_manager.api.ProcessFileStatus;
 import com.farao_community.farao.gridcapa.task_manager.api.ProcessRunDto;
 import com.farao_community.farao.gridcapa.task_manager.api.TaskDto;
 import com.farao_community.farao.gridcapa.task_manager.api.TaskParameterDto;
+import com.farao_community.farao.gridcapa.task_manager.api.TaskStatus;
 import com.farao_community.farao.gridcapa.task_manager.app.entities.ProcessRun;
 import com.farao_community.farao.gridcapa.task_manager.app.repository.TaskRepository;
 import com.farao_community.farao.gridcapa.task_manager.app.configuration.TaskManagerConfigurationProperties;
@@ -96,6 +97,17 @@ public class TaskDtoBuilderService {
                 .forEach(dto -> taskMap.put(dto.getTimestamp(), dto));
 
         return taskMap.values().stream().toList();
+    }
+
+    public boolean getTasksStatusAllOverForPostProcessing(LocalDate businessDate) {
+        LocalDateTime businessDateStartTime = businessDate.atTime(0, 0);
+        LocalDateTime businessDateEndTime = businessDate.atTime(23, 30);
+        ZoneOffset zoneOffSetStart = localZone.getRules().getOffset(businessDateStartTime);
+        ZoneOffset zoneOffSetEnd = localZone.getRules().getOffset(businessDateEndTime);
+        OffsetDateTime startTimestamp = businessDateStartTime.atOffset(zoneOffSetStart);
+        OffsetDateTime endTimestamp = businessDateEndTime.atOffset(zoneOffSetEnd);
+        List<TaskStatus> statuses = taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(startTimestamp, endTimestamp);
+        return statuses.stream().allMatch(TaskStatus::isOver);
     }
 
     public List<TaskDto> getListRunningTasksDto() {

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
@@ -97,7 +97,7 @@ public class TaskDtoBuilderService {
     public boolean areAllTasksOverForBusinessDate(final LocalDate businessDate) {
         final OffsetDateTime startTimestamp = getDateAtOffset(businessDate.atTime(0, 0));
         final OffsetDateTime endTimestamp = getDateAtOffset(businessDate.atTime(23, 59));
-        final Set<TaskStatus> statuses = taskRepository.findTaskStatusByTimestampBetween(startTimestamp, endTimestamp);
+        final Set<TaskStatus> statuses = taskRepository.findTaskStatusesByTimestampBetween(startTimestamp, endTimestamp);
         return statuses.stream().allMatch(TaskStatus::isOver);
     }
 

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
@@ -75,12 +75,10 @@ public class TaskDtoBuilderService {
     }
 
     public List<TaskDto> getListTasksDto(final LocalDate businessDate) {
-
         final OffsetDateTime startTimestamp = properties.getProcess().isOnTheHourProcess()
                 ? getDateAtOffset(businessDate.atTime(0, 0))
                 : getDateAtOffset(businessDate.atTime(0, 30));
         final OffsetDateTime endTimestamp = getDateAtOffset(businessDate.atTime(23, 59));
-
         Set<Task> tasks = taskRepository.findAllByTimestampBetweenForBusinessDayView(startTimestamp, endTimestamp);
         Map<OffsetDateTime, TaskDto> taskMap = new HashMap<>();
         for (OffsetDateTime loopTimestamp = startTimestamp;
@@ -90,11 +88,9 @@ public class TaskDtoBuilderService {
             OffsetDateTime taskTimeStamp = loopTimestamp.atZoneSameInstant(UTC_ZONE).toOffsetDateTime();
             taskMap.put(taskTimeStamp, getEmptyTask(taskTimeStamp));
         }
-
         tasks.stream()
                 .map(this::createDtoFromEntityWithoutProcessEvents)
                 .forEach(dto -> taskMap.put(dto.getTimestamp(), dto));
-
         return taskMap.values().stream().toList();
     }
 

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
@@ -75,8 +75,11 @@ public class TaskDtoBuilderService {
     }
 
     public List<TaskDto> getListTasksDto(final LocalDate businessDate) {
-        final OffsetDateTime startTimestamp = getDateAtOffset(businessDate.atTime(0, 30));
-        final OffsetDateTime endTimestamp = getDateAtOffset(businessDate.atTime(23, 30));
+
+        final OffsetDateTime startTimestamp = properties.getProcess().isOnTheHourProcess() ?
+                getDateAtOffset(businessDate.atTime(0, 0)) :
+                getDateAtOffset(businessDate.atTime(0, 30));
+        final OffsetDateTime endTimestamp = getDateAtOffset(businessDate.atTime(23, 59));
 
         Set<Task> tasks = taskRepository.findAllByTimestampBetweenForBusinessDayView(startTimestamp, endTimestamp);
         Map<OffsetDateTime, TaskDto> taskMap = new HashMap<>();

--- a/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
+++ b/gridcapa-task-manager-app/src/main/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderService.java
@@ -76,9 +76,9 @@ public class TaskDtoBuilderService {
 
     public List<TaskDto> getListTasksDto(final LocalDate businessDate) {
 
-        final OffsetDateTime startTimestamp = properties.getProcess().isOnTheHourProcess() ?
-                getDateAtOffset(businessDate.atTime(0, 0)) :
-                getDateAtOffset(businessDate.atTime(0, 30));
+        final OffsetDateTime startTimestamp = properties.getProcess().isOnTheHourProcess()
+                ? getDateAtOffset(businessDate.atTime(0, 0))
+                : getDateAtOffset(businessDate.atTime(0, 30));
         final OffsetDateTime endTimestamp = getDateAtOffset(businessDate.atTime(23, 59));
 
         Set<Task> tasks = taskRepository.findAllByTimestampBetweenForBusinessDayView(startTimestamp, endTimestamp);

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerControllerTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerControllerTest.java
@@ -313,7 +313,7 @@ class TaskManagerControllerTest {
     @Test
     void testAreAllTasksFromBusinessDateOverShouldReturnFalse() {
         LocalDate businessDate = LocalDate.parse("2021-01-01");
-        Mockito.when(taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(Mockito.any(), Mockito.any())).thenReturn(List.of(TaskStatus.CREATED));
+        Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(), Mockito.any())).thenReturn(List.of(TaskStatus.CREATED));
         ResponseEntity<Boolean> response = taskManagerController.areAllTasksFromBusinessDateOver(businessDate.toString());
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(false, response.getBody());
@@ -331,7 +331,7 @@ class TaskManagerControllerTest {
             taskStatuses.add(TaskStatus.ERROR);
             startTimestamp = startTimestamp.plusHours(1).atZoneSameInstant(zone).toOffsetDateTime();
         }
-        Mockito.when(taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(Mockito.any(), Mockito.any())).thenReturn(taskStatuses);
+        Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(), Mockito.any())).thenReturn(taskStatuses);
         ResponseEntity<Boolean> response = taskManagerController.areAllTasksFromBusinessDateOver(businessDate.toString());
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(true, response.getBody());

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerControllerTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerControllerTest.java
@@ -40,9 +40,10 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -313,7 +314,7 @@ class TaskManagerControllerTest {
     @Test
     void testAreAllTasksFromBusinessDateOverShouldReturnFalse() {
         LocalDate businessDate = LocalDate.parse("2021-01-01");
-        Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(), Mockito.any())).thenReturn(List.of(TaskStatus.CREATED));
+        Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(), Mockito.any())).thenReturn(Set.of(TaskStatus.CREATED));
         ResponseEntity<Boolean> response = taskManagerController.areAllTasksFromBusinessDateOver(businessDate.toString());
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(false, response.getBody());
@@ -326,7 +327,7 @@ class TaskManagerControllerTest {
         LocalDateTime businessDateStartTime = businessDate.atTime(0, 30);
         ZoneOffset zoneOffSet = zone.getRules().getOffset(businessDateStartTime);
         OffsetDateTime startTimestamp = businessDateStartTime.atOffset(zoneOffSet);
-        List<TaskStatus> taskStatuses = new ArrayList<>();
+        Set<TaskStatus> taskStatuses = new HashSet<>();
         while (startTimestamp.getDayOfMonth() == businessDate.getDayOfMonth()) {
             taskStatuses.add(TaskStatus.ERROR);
             startTimestamp = startTimestamp.plusHours(1).atZoneSameInstant(zone).toOffsetDateTime();

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerControllerTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerControllerTest.java
@@ -314,7 +314,7 @@ class TaskManagerControllerTest {
     @Test
     void testAreAllTasksFromBusinessDateOverShouldReturnFalse() {
         LocalDate businessDate = LocalDate.parse("2021-01-01");
-        Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(), Mockito.any())).thenReturn(Set.of(TaskStatus.CREATED));
+        Mockito.when(taskRepository.findTaskStatusesByTimestampBetween(Mockito.any(), Mockito.any())).thenReturn(Set.of(TaskStatus.CREATED));
         ResponseEntity<Boolean> response = taskManagerController.areAllTasksFromBusinessDateOver(businessDate.toString());
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(false, response.getBody());
@@ -332,7 +332,7 @@ class TaskManagerControllerTest {
             taskStatuses.add(TaskStatus.ERROR);
             startTimestamp = startTimestamp.plusHours(1).atZoneSameInstant(zone).toOffsetDateTime();
         }
-        Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(), Mockito.any())).thenReturn(taskStatuses);
+        Mockito.when(taskRepository.findTaskStatusesByTimestampBetween(Mockito.any(), Mockito.any())).thenReturn(taskStatuses);
         ResponseEntity<Boolean> response = taskManagerController.areAllTasksFromBusinessDateOver(businessDate.toString());
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(true, response.getBody());

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerControllerTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/TaskManagerControllerTest.java
@@ -40,10 +40,9 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -314,9 +313,7 @@ class TaskManagerControllerTest {
     @Test
     void testAreAllTasksFromBusinessDateOverShouldReturnFalse() {
         LocalDate businessDate = LocalDate.parse("2021-01-01");
-        Task task = new Task();
-        task.setStatus(TaskStatus.CREATED);
-        Mockito.when(taskRepository.findAllByTimestampBetweenForBusinessDayView(Mockito.any(), Mockito.any())).thenReturn(Set.of(task));
+        Mockito.when(taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(Mockito.any(), Mockito.any())).thenReturn(List.of(TaskStatus.CREATED));
         ResponseEntity<Boolean> response = taskManagerController.areAllTasksFromBusinessDateOver(businessDate.toString());
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(false, response.getBody());
@@ -329,14 +326,12 @@ class TaskManagerControllerTest {
         LocalDateTime businessDateStartTime = businessDate.atTime(0, 30);
         ZoneOffset zoneOffSet = zone.getRules().getOffset(businessDateStartTime);
         OffsetDateTime startTimestamp = businessDateStartTime.atOffset(zoneOffSet);
-        Set<Task> tasks = new HashSet<>();
+        List<TaskStatus> taskStatuses = new ArrayList<>();
         while (startTimestamp.getDayOfMonth() == businessDate.getDayOfMonth()) {
-            Task task = new Task(startTimestamp.atZoneSameInstant(ZoneId.of("Z")).toOffsetDateTime());
-            task.setStatus(TaskStatus.ERROR);
-            tasks.add(task);
+            taskStatuses.add(TaskStatus.ERROR);
             startTimestamp = startTimestamp.plusHours(1).atZoneSameInstant(zone).toOffsetDateTime();
         }
-        Mockito.when(taskRepository.findAllByTimestampBetweenForBusinessDayView(Mockito.any(), Mockito.any())).thenReturn(tasks);
+        Mockito.when(taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(Mockito.any(), Mockito.any())).thenReturn(taskStatuses);
         ResponseEntity<Boolean> response = taskManagerController.areAllTasksFromBusinessDateOver(businessDate.toString());
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(true, response.getBody());

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/configuration/TaskManagerConfigurationPropertiesTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/configuration/TaskManagerConfigurationPropertiesTest.java
@@ -31,7 +31,7 @@ class TaskManagerConfigurationPropertiesTest {
     }
 
     @Test
-    void getISOnTheHourProcessDefaultsToFalseTest() {
+    void getIsOnTheHourProcessDefaultsToFalseTest() {
         Assertions.assertThat(properties.getProcess().isOnTheHourProcess())
                 .isFalse();
     }

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/configuration/TaskManagerConfigurationPropertiesTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/configuration/TaskManagerConfigurationPropertiesTest.java
@@ -6,6 +6,7 @@
  */
 package com.farao_community.farao.gridcapa.task_manager.app.configuration;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,5 +28,11 @@ class TaskManagerConfigurationPropertiesTest {
     void getProcessTimezoneTest() {
         ZoneId timezone = properties.getProcessTimezone();
         assertEquals(ZoneId.of("CET"), timezone);
+    }
+
+    @Test
+    void getISOnTheHourProcessDefaultsToFalseTest() {
+        Assertions.assertThat(properties.getProcess().isOnTheHourProcess())
+                .isFalse();
     }
 }

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepositoryTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepositoryTest.java
@@ -28,11 +28,11 @@ class TaskRepositoryTest {
     }
 
     @Test
-    void findTaskStatusByTimestampBetweenTest() {
+    void findTaskStatusesByTimestampBetweenTest() {
         final OffsetDateTime offsetDateTimeBegin = OffsetDateTime.parse("2025-10-25T22:00Z");
         final OffsetDateTime offsetDateTimeMiddle = OffsetDateTime.parse("2025-10-26T12:30Z");
         final OffsetDateTime offsetDateTimeEnd = OffsetDateTime.parse("2025-10-26T22:30Z");
-        final Set<TaskStatus> emptyResult = taskRepository.findTaskStatusByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
+        final Set<TaskStatus> emptyResult = taskRepository.findTaskStatusesByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
         org.assertj.core.api.Assertions.assertThat(emptyResult)
                 .isNotNull()
                 .isEmpty();
@@ -42,7 +42,7 @@ class TaskRepositoryTest {
         taskRepository.save(new Task(offsetDateTimeEnd));
         taskRepository.save(new Task(offsetDateTimeBegin));
         taskRepository.save(new Task(offsetDateTimeAfter));
-        final Set<TaskStatus> result = taskRepository.findTaskStatusByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
+        final Set<TaskStatus> result = taskRepository.findTaskStatusesByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
         org.assertj.core.api.Assertions.assertThat(result)
                 .isNotNull()
                 .isNotEmpty()
@@ -51,7 +51,7 @@ class TaskRepositoryTest {
         final Task middle = new Task(offsetDateTimeMiddle);
         middle.setStatus(TaskStatus.SUCCESS);
         taskRepository.save(middle);
-        final Set<TaskStatus> result2 = taskRepository.findTaskStatusByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
+        final Set<TaskStatus> result2 = taskRepository.findTaskStatusesByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
         org.assertj.core.api.Assertions.assertThat(result2)
                 .isNotNull()
                 .isNotEmpty()

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepositoryTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.farao_community.farao.gridcapa.task_manager.app.repository;
 
+import com.farao_community.farao.gridcapa.task_manager.api.TaskStatus;
 import com.farao_community.farao.gridcapa.task_manager.app.entities.Task;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -7,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @SpringBootTest
@@ -23,5 +25,26 @@ class TaskRepositoryTest {
         final Optional<Task> persistedTask = taskRepository.findByTimestamp(offsetDateTime);
         Assertions.assertTrue(persistedTask.isPresent());
         Assertions.assertEquals(offsetDateTime, persistedTask.get().getTimestamp());
+    }
+
+    @Test
+    void findTaskStatusByTimestampBetweenForPostProcessorTest() {
+        final OffsetDateTime offsetDateTimeBegin = OffsetDateTime.parse("2025-10-25T22:00Z");
+        final OffsetDateTime offsetDateTimeEnd = OffsetDateTime.parse("2025-10-26T22:30Z");
+        final List<TaskStatus> emptyResult = taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(offsetDateTimeBegin, offsetDateTimeEnd);
+        org.assertj.core.api.Assertions.assertThat(emptyResult)
+                .isNotNull()
+                .isEmpty();
+        final OffsetDateTime offsetDateTimeBefore = OffsetDateTime.parse("2025-10-25T21:59Z");
+        final OffsetDateTime offsetDateTimeAfter = OffsetDateTime.parse("2025-10-26T22:31Z");
+        taskRepository.save(new Task(offsetDateTimeBefore));
+        taskRepository.save(new Task(offsetDateTimeEnd));
+        taskRepository.save(new Task(offsetDateTimeBegin));
+        taskRepository.save(new Task(offsetDateTimeAfter));
+        final List<TaskStatus> result = taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(offsetDateTimeBegin, offsetDateTimeEnd);
+        org.assertj.core.api.Assertions.assertThat(result)
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(2);
     }
 }

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepositoryTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepositoryTest.java
@@ -28,10 +28,10 @@ class TaskRepositoryTest {
     }
 
     @Test
-    void findTaskStatusByTimestampBetweenForPostProcessorTest() {
+    void findTaskStatusByTimestampBetweenTest() {
         final OffsetDateTime offsetDateTimeBegin = OffsetDateTime.parse("2025-10-25T22:00Z");
         final OffsetDateTime offsetDateTimeEnd = OffsetDateTime.parse("2025-10-26T22:30Z");
-        final List<TaskStatus> emptyResult = taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(offsetDateTimeBegin, offsetDateTimeEnd);
+        final List<TaskStatus> emptyResult = taskRepository.findTaskStatusByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
         org.assertj.core.api.Assertions.assertThat(emptyResult)
                 .isNotNull()
                 .isEmpty();
@@ -41,7 +41,7 @@ class TaskRepositoryTest {
         taskRepository.save(new Task(offsetDateTimeEnd));
         taskRepository.save(new Task(offsetDateTimeBegin));
         taskRepository.save(new Task(offsetDateTimeAfter));
-        final List<TaskStatus> result = taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(offsetDateTimeBegin, offsetDateTimeEnd);
+        final List<TaskStatus> result = taskRepository.findTaskStatusByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
         org.assertj.core.api.Assertions.assertThat(result)
                 .isNotNull()
                 .isNotEmpty()

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepositoryTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/repository/TaskRepositoryTest.java
@@ -8,8 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @SpringBootTest
 class TaskRepositoryTest {
@@ -30,8 +30,9 @@ class TaskRepositoryTest {
     @Test
     void findTaskStatusByTimestampBetweenTest() {
         final OffsetDateTime offsetDateTimeBegin = OffsetDateTime.parse("2025-10-25T22:00Z");
+        final OffsetDateTime offsetDateTimeMiddle = OffsetDateTime.parse("2025-10-26T12:30Z");
         final OffsetDateTime offsetDateTimeEnd = OffsetDateTime.parse("2025-10-26T22:30Z");
-        final List<TaskStatus> emptyResult = taskRepository.findTaskStatusByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
+        final Set<TaskStatus> emptyResult = taskRepository.findTaskStatusByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
         org.assertj.core.api.Assertions.assertThat(emptyResult)
                 .isNotNull()
                 .isEmpty();
@@ -41,10 +42,20 @@ class TaskRepositoryTest {
         taskRepository.save(new Task(offsetDateTimeEnd));
         taskRepository.save(new Task(offsetDateTimeBegin));
         taskRepository.save(new Task(offsetDateTimeAfter));
-        final List<TaskStatus> result = taskRepository.findTaskStatusByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
+        final Set<TaskStatus> result = taskRepository.findTaskStatusByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
         org.assertj.core.api.Assertions.assertThat(result)
                 .isNotNull()
                 .isNotEmpty()
+                .hasSize(1);
+
+        final Task middle = new Task(offsetDateTimeMiddle);
+        middle.setStatus(TaskStatus.SUCCESS);
+        taskRepository.save(middle);
+        final Set<TaskStatus> result2 = taskRepository.findTaskStatusByTimestampBetween(offsetDateTimeBegin, offsetDateTimeEnd);
+        org.assertj.core.api.Assertions.assertThat(result2)
+                .isNotNull()
+                .isNotEmpty()
                 .hasSize(2);
+
     }
 }

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
@@ -342,11 +342,11 @@ class TaskDtoBuilderServiceTest {
 
     @Test
     void testAreAllTasksOverForBusinessDate() {
-        final List<TaskStatus> statusesKO = List.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS, TaskStatus.CREATED);
+        final Set<TaskStatus> statusesKO = Set.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS, TaskStatus.CREATED);
         Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesKO);
         Assertions.assertThat(taskDtoBuilderService.areAllTasksOverForBusinessDate(LocalDate.now()))
                 .isFalse();
-        final List<TaskStatus> statusesOK = List.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS);
+        final Set<TaskStatus> statusesOK = Set.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS);
         Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesOK);
         Assertions.assertThat(taskDtoBuilderService.areAllTasksOverForBusinessDate(LocalDate.now()))
                 .isTrue();
@@ -404,8 +404,8 @@ class TaskDtoBuilderServiceTest {
         }
 
         @Override
-        public List<TaskStatus> findTaskStatusByTimestampBetween(OffsetDateTime startingTimestamp, OffsetDateTime endingTimestamp) {
-            return List.of();
+        public Set<TaskStatus> findTaskStatusByTimestampBetween(OffsetDateTime startingTimestamp, OffsetDateTime endingTimestamp) {
+            return Set.of();
         }
 
         @Override

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
@@ -303,14 +303,14 @@ class TaskDtoBuilderServiceTest {
     }
 
     @Test
-    void testGetTasksStatusAllOverForPostProcessing() {
+    void testAreAllTasksOverForBusinessDate() {
         final List<TaskStatus> statusesKO = List.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS, TaskStatus.CREATED);
-        Mockito.when(taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesKO);
-        Assertions.assertThat(taskDtoBuilderService.getTasksStatusAllOverForPostProcessing(LocalDate.now()))
+        Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesKO);
+        Assertions.assertThat(taskDtoBuilderService.areAllTasksOverForBusinessDate(LocalDate.now()))
                 .isFalse();
         final List<TaskStatus> statusesOK = List.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS);
-        Mockito.when(taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesOK);
-        Assertions.assertThat(taskDtoBuilderService.getTasksStatusAllOverForPostProcessing(LocalDate.now()))
+        Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesOK);
+        Assertions.assertThat(taskDtoBuilderService.areAllTasksOverForBusinessDate(LocalDate.now()))
                 .isTrue();
     }
 
@@ -366,7 +366,7 @@ class TaskDtoBuilderServiceTest {
         }
 
         @Override
-        public List<TaskStatus> findTaskStatusByTimestampBetweenForPostProcessor(OffsetDateTime startingTimestamp, OffsetDateTime endingTimestamp) {
+        public List<TaskStatus> findTaskStatusByTimestampBetween(OffsetDateTime startingTimestamp, OffsetDateTime endingTimestamp) {
             return List.of();
         }
 

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
@@ -355,12 +355,12 @@ class TaskDtoBuilderServiceTest {
     private class TaskRepositoryMock implements TaskRepository {
 
         @Override
-        public Optional<Task> findByIdAndFetchProcessFiles(UUID id) {
+        public Optional<Task> findByIdAndFetchProcessFiles(final UUID id) {
             return Optional.empty();
         }
 
         @Override
-        public Optional<Task> findByTimestamp(OffsetDateTime timestamp) {
+        public Optional<Task> findByTimestamp(final OffsetDateTime timestamp) {
             return Optional.empty();
         }
 
@@ -391,7 +391,7 @@ class TaskDtoBuilderServiceTest {
         }
 
         @Override
-        public Set<Task> findAllByTimestampBetweenForBusinessDayView(OffsetDateTime startingTimestamp, OffsetDateTime endingTimestamp) {
+        public Set<Task> findAllByTimestampBetweenForBusinessDayView(final OffsetDateTime startingTimestamp, final OffsetDateTime endingTimestamp) {
             Set<Task> tasks = new HashSet<>();
             OffsetDateTime time = startingTimestamp;
             while (!time.isAfter(endingTimestamp)) {
@@ -404,7 +404,7 @@ class TaskDtoBuilderServiceTest {
         }
 
         @Override
-        public Set<TaskStatus> findTaskStatusByTimestampBetween(OffsetDateTime startingTimestamp, OffsetDateTime endingTimestamp) {
+        public Set<TaskStatus> findTaskStatusByTimestampBetween(final OffsetDateTime startingTimestamp, final OffsetDateTime endingTimestamp) {
             return Set.of();
         }
 

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
@@ -302,6 +302,18 @@ class TaskDtoBuilderServiceTest {
         assertEquals(25, customTaskDtoBuilderService.getListTasksDto(localDate).size());
     }
 
+    @Test
+    void testGetTasksStatusAllOverForPostProcessing() {
+        final List<TaskStatus> statusesKO = List.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS, TaskStatus.CREATED);
+        Mockito.when(taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesKO);
+        Assertions.assertThat(taskDtoBuilderService.getTasksStatusAllOverForPostProcessing(LocalDate.now()))
+                .isFalse();
+        final List<TaskStatus> statusesOK = List.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS);
+        Mockito.when(taskRepository.findTaskStatusByTimestampBetweenForPostProcessor(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesOK);
+        Assertions.assertThat(taskDtoBuilderService.getTasksStatusAllOverForPostProcessing(LocalDate.now()))
+                .isTrue();
+    }
+
     private class TaskRepositoryMock implements TaskRepository {
 
         @Override
@@ -351,6 +363,11 @@ class TaskDtoBuilderServiceTest {
                 time = time.plusHours(1);
             }
             return tasks;
+        }
+
+        @Override
+        public List<TaskStatus> findTaskStatusByTimestampBetweenForPostProcessor(OffsetDateTime startingTimestamp, OffsetDateTime endingTimestamp) {
+            return List.of();
         }
 
         @Override

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
@@ -303,6 +303,44 @@ class TaskDtoBuilderServiceTest {
     }
 
     @Test
+    void testGetListTasksDto24TSOnTheHour() {
+        final TaskManagerConfigurationProperties.ProcessProperties processProperties = Mockito.mock(TaskManagerConfigurationProperties.ProcessProperties.class);
+        Mockito.when(processProperties.getTimezone()).thenReturn("CET");
+        Mockito.when(processProperties.isOnTheHourProcess()).thenReturn(true);
+        final TaskManagerConfigurationProperties properties = new TaskManagerConfigurationProperties(processProperties, new ArrayList<>());
+        final TaskRepository customTaskRepository = new TaskRepositoryMock();
+        final ParameterService parameterService = Mockito.mock(ParameterService.class);
+        final TaskDtoBuilderService customTaskDtoBuilderService = new TaskDtoBuilderService(properties, customTaskRepository, parameterService);
+        final LocalDate localDate = LocalDate.of(2025, 11, 26);
+        final List<TaskDto> listTasksDto = customTaskDtoBuilderService.getListTasksDto(localDate);
+        final List<TaskDto> sortedTasksDto = listTasksDto.stream().sorted((t1, t2) -> t1.getTimestamp().compareTo(t2.getTimestamp())).toList();
+        Assertions.assertThat(sortedTasksDto)
+                .isNotEmpty()
+                .hasSize(24)
+                .first()
+                .hasFieldOrPropertyWithValue("timestamp", OffsetDateTime.parse("2025-11-25T23:00Z"));
+    }
+
+    @Test
+    void testGetListTasksDto24TSOnTheHalfHour() {
+        final TaskManagerConfigurationProperties.ProcessProperties processProperties = Mockito.mock(TaskManagerConfigurationProperties.ProcessProperties.class);
+        Mockito.when(processProperties.getTimezone()).thenReturn("CET");
+        Mockito.when(processProperties.isOnTheHourProcess()).thenReturn(false);
+        final TaskManagerConfigurationProperties properties = new TaskManagerConfigurationProperties(processProperties, new ArrayList<>());
+        final TaskRepository customTaskRepository = new TaskRepositoryMock();
+        final ParameterService parameterService = Mockito.mock(ParameterService.class);
+        final TaskDtoBuilderService customTaskDtoBuilderService = new TaskDtoBuilderService(properties, customTaskRepository, parameterService);
+        final LocalDate localDate = LocalDate.of(2025, 11, 26);
+        final List<TaskDto> listTasksDto = customTaskDtoBuilderService.getListTasksDto(localDate);
+        final List<TaskDto> sortedTasksDto = listTasksDto.stream().sorted((t1, t2) -> t1.getTimestamp().compareTo(t2.getTimestamp())).toList();
+        Assertions.assertThat(sortedTasksDto)
+                .isNotEmpty()
+                .hasSize(24)
+                .first()
+                .hasFieldOrPropertyWithValue("timestamp", OffsetDateTime.parse("2025-11-25T23:30Z"));
+    }
+
+    @Test
     void testAreAllTasksOverForBusinessDate() {
         final List<TaskStatus> statusesKO = List.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS, TaskStatus.CREATED);
         Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesKO);

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
@@ -345,11 +345,11 @@ class TaskDtoBuilderServiceTest {
     void testAreAllTasksOverForBusinessDate() {
         final LocalDate localDate = LocalDate.of(2025, 11, 26);
         final Set<TaskStatus> statusesKO = Set.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS, TaskStatus.CREATED);
-        Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesKO);
+        Mockito.when(taskRepository.findTaskStatusesByTimestampBetween(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesKO);
         Assertions.assertThat(taskDtoBuilderService.areAllTasksOverForBusinessDate(localDate))
                 .isFalse();
         final Set<TaskStatus> statusesOK = Set.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS);
-        Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesOK);
+        Mockito.when(taskRepository.findTaskStatusesByTimestampBetween(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesOK);
         Assertions.assertThat(taskDtoBuilderService.areAllTasksOverForBusinessDate(localDate))
                 .isTrue();
     }
@@ -406,7 +406,7 @@ class TaskDtoBuilderServiceTest {
         }
 
         @Override
-        public Set<TaskStatus> findTaskStatusByTimestampBetween(final OffsetDateTime startingTimestamp, final OffsetDateTime endingTimestamp) {
+        public Set<TaskStatus> findTaskStatusesByTimestampBetween(final OffsetDateTime startingTimestamp, final OffsetDateTime endingTimestamp) {
             return Set.of();
         }
 

--- a/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
+++ b/gridcapa-task-manager-app/src/test/java/com/farao_community/farao/gridcapa/task_manager/app/service/TaskDtoBuilderServiceTest.java
@@ -36,6 +36,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -313,7 +314,7 @@ class TaskDtoBuilderServiceTest {
         final TaskDtoBuilderService customTaskDtoBuilderService = new TaskDtoBuilderService(properties, customTaskRepository, parameterService);
         final LocalDate localDate = LocalDate.of(2025, 11, 26);
         final List<TaskDto> listTasksDto = customTaskDtoBuilderService.getListTasksDto(localDate);
-        final List<TaskDto> sortedTasksDto = listTasksDto.stream().sorted((t1, t2) -> t1.getTimestamp().compareTo(t2.getTimestamp())).toList();
+        final List<TaskDto> sortedTasksDto = listTasksDto.stream().sorted(Comparator.comparing(TaskDto::getTimestamp)).toList();
         Assertions.assertThat(sortedTasksDto)
                 .isNotEmpty()
                 .hasSize(24)
@@ -332,7 +333,7 @@ class TaskDtoBuilderServiceTest {
         final TaskDtoBuilderService customTaskDtoBuilderService = new TaskDtoBuilderService(properties, customTaskRepository, parameterService);
         final LocalDate localDate = LocalDate.of(2025, 11, 26);
         final List<TaskDto> listTasksDto = customTaskDtoBuilderService.getListTasksDto(localDate);
-        final List<TaskDto> sortedTasksDto = listTasksDto.stream().sorted((t1, t2) -> t1.getTimestamp().compareTo(t2.getTimestamp())).toList();
+        final List<TaskDto> sortedTasksDto = listTasksDto.stream().sorted(Comparator.comparing(TaskDto::getTimestamp)).toList();
         Assertions.assertThat(sortedTasksDto)
                 .isNotEmpty()
                 .hasSize(24)
@@ -342,13 +343,14 @@ class TaskDtoBuilderServiceTest {
 
     @Test
     void testAreAllTasksOverForBusinessDate() {
+        final LocalDate localDate = LocalDate.of(2025, 11, 26);
         final Set<TaskStatus> statusesKO = Set.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS, TaskStatus.CREATED);
         Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesKO);
-        Assertions.assertThat(taskDtoBuilderService.areAllTasksOverForBusinessDate(LocalDate.now()))
+        Assertions.assertThat(taskDtoBuilderService.areAllTasksOverForBusinessDate(localDate))
                 .isFalse();
         final Set<TaskStatus> statusesOK = Set.of(TaskStatus.ERROR, TaskStatus.INTERRUPTED, TaskStatus.SUCCESS);
         Mockito.when(taskRepository.findTaskStatusByTimestampBetween(Mockito.any(OffsetDateTime.class), Mockito.any(OffsetDateTime.class))).thenReturn(statusesOK);
-        Assertions.assertThat(taskDtoBuilderService.areAllTasksOverForBusinessDate(LocalDate.now()))
+        Assertions.assertThat(taskDtoBuilderService.areAllTasksOverForBusinessDate(localDate))
                 .isTrue();
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config flag to switch between on-the-hour and half-hour processing; timestamp window extended to end-of-day.
  * New query exposing distinct task statuses over a time range.
  * Controller now performs a direct all-tasks-over check for a business date.

* **Tests**
  * Added unit tests for 24-hour timestamp generation (hour and half-hour) and for the all-tasks-over evaluation.
  * Repository tests validate status-based querying.

* **Bug Fixes / Improvements**
  * Services build full-day per-hour task maps for more accurate status evaluation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->